### PR TITLE
Allow session.install() to be called with env param

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -167,5 +167,8 @@ class VirtualEnv(ProcessEnv):
 
         return True
 
-    def install(self, *args):
+    def install(self, *args, **kwargs):
+        env = kwargs.get('env', None)
+        if env:
+            self.env.update(env)
         self.run(('pip', 'install', '--upgrade') + args)

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -55,12 +55,12 @@ class ProcessEnv(object):
     def run(self, args, in_venv=True, env=None):
         """Runs a command. By default, the command runs within the
         environment."""
-        env_copy = self.env.copy() if in_venv else None
-        if env_copy is not None and env is not None:
-            env_copy.update(env)
+        if in_venv:
+            env = env or {}
+            env.update(self.env)
         return Command(
             args=args,
-            env=env_copy,
+            env=env,
             silent=True,
             path=self.bin if in_venv else None).run()
 

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -52,12 +52,15 @@ class ProcessEnv(object):
     def bin(self):
         return self._bin
 
-    def run(self, args, in_venv=True):
+    def run(self, args, in_venv=True, env=None):
         """Runs a command. By default, the command runs within the
         environment."""
+        env_copy = self.env.copy() if in_venv else None
+        if env_copy is not None and env is not None:
+            env_copy.update(env)
         return Command(
             args=args,
-            env=self.env if in_venv else None,
+            env=env_copy,
             silent=True,
             path=self.bin if in_venv else None).run()
 
@@ -169,6 +172,4 @@ class VirtualEnv(ProcessEnv):
 
     def install(self, *args, **kwargs):
         env = kwargs.get('env', None)
-        if env:
-            self.env.update(env)
-        self.run(('pip', 'install', '--upgrade') + args)
+        self.run(('pip', 'install', '--upgrade') + args, env=env)

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -194,6 +194,12 @@ def test_install(make_one):
         mock_run.assert_called_with(
             ('pip', 'install', '--upgrade', '-r', 'somefile.txt'))
 
+        venv.install('foo', env={'DEBUG': 'true'})
+        mock_run.assert_called_with(
+            ('pip', 'install', '--upgrade', 'foo'))
+        assert 'DEBUG' in venv.env
+        assert venv.env['DEBUG'] == 'true'
+
 
 def test__resolved_interpreter_none(make_one):
     # Establish that the _resolved_interpreter method is a no-op if the


### PR DESCRIPTION
This should allow the behavior desired in #79 

I relied on the subclassing of `ProcessEnv` by `VirtualEnv` to update the default environment with the one provided in the `session.install`. Since the call trace translates everything into a `Command` to be run, I rely on the validations made there instead of rolling my own.
If there's any way to make it cleaner or more reliable, please let me know.

Also, I added a test to verify this is working, but I'm not sure the way I did it is the best way to go, so if there's a better way to test this new behavior I'd be happy to hear it :)
🐍 