### PR TITLE
Adding support for 32-bit binaries on Windows.

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -125,6 +125,12 @@ Nox has provisional support for running on Windows. However, depending on your W
 * `Python issue 24493 <http://bugs.python.org/issue24493>`_
 * `Virtualenv issue 774 <https://github.com/pypa/virtualenv/issues/774>`_
 
+The Python binaries on Windows are found via the Python `Launcher`_ for
+Windows (``py``). For example, Python 3.5 can be found by determining which
+executable is invoked by ``py -3.5``. If a given test needs to use the 32-bit
+version of a given Python, then ``X.Y-32`` should be used as the version.
+
+.. _Launcher: https://docs.python.org/3/using/windows.html#python-launcher-for-windows
 
 Converting from tox
 -------------------

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -249,7 +249,9 @@ def test__resolved_interpreter_windows_full_path(sysfind, system, make_one):
 )
 @mock.patch.object(platform, "system", return_value="Windows")
 @mock.patch.object(py.path.local, "sysfind")
-def test__resolved_interpreter_windows_pyexe(sysfind, system, make_one, input_, expected):
+def test__resolved_interpreter_windows_pyexe(
+    sysfind, system, make_one, input_, expected
+):
     # Establish that if we get a standard pythonX.Y path, we look it
     # up via the py launcher on Windows.
     venv, _ = make_one(interpreter=input_)


### PR DESCRIPTION
An alternative implementation (and possibly a better one) would be to allow `arch` as an optional argument to `nox.session`. For example:

```python
@nox.session(python=["2.7", "3.7"], arch=["32", "64"])
def tests(session):
    session.install("pytest")
    session.install("-r", "requirements-dev.txt")
    session.install("-e", ".")
    session.run("py.test")
```

This would also give a "solution" to #60.

The real silly thing: I'm not sure anyone cares about 32-bit support. I used to test my OS X binaries for `bezier` in 32-bit, but then NumPy discontinued 32-bit support on OS X. Maybe that's a different beast since Apple controls the hardware?