### PR TITLE
Using `os.pathsep` instead of a hardcoded `':'`.

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -47,7 +47,7 @@ class ProcessEnv:
 
         if self.bin:
             self.env['PATH'] = os.pathsep.join(
-                [self.bin, self.env.get('PATH')])
+                [self.bin, self.env.get('PATH', '')])
 
     @property
     def bin(self):

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -46,7 +46,8 @@ class ProcessEnv:
             self.env.pop(key, None)
 
         if self.bin:
-            self.env['PATH'] = ':'.join([self.bin, self.env.get('PATH')])
+            self.env['PATH'] = os.pathsep.join(
+                [self.bin, self.env.get('PATH')])
 
     @property
     def bin(self):


### PR DESCRIPTION
@theacodes Do I need any tests for this?