### PR TITLE
Storing `platform.system()` as global in `nox.virtualenv`.

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -28,6 +28,7 @@ from nox.logger import logger
 _BLACKLISTED_ENV_VARS = frozenset(
     ["PIP_RESPECT_VIRTUALENV", "PIP_REQUIRE_VIRTUALENV", "__PYVENV_LAUNCHER__"]
 )
+_SYSTEM = platform.system()
 
 
 class ProcessEnv:
@@ -144,7 +145,7 @@ class VirtualEnv(ProcessEnv):
                 xy_version = self.interpreter
 
         # Sanity check: We only need the rest of this behavior on Windows.
-        if platform.system() != "Windows":
+        if _SYSTEM != "Windows":
             if xy_version.endswith("-32"):
                 raise RuntimeError(
                     "Locating 32-bit Python ({!r}) is "
@@ -175,7 +176,7 @@ class VirtualEnv(ProcessEnv):
     @property
     def bin(self):
         """Returns the location of the virtualenv's bin folder."""
-        if platform.system() == "Windows":
+        if _SYSTEM == "Windows":
             return os.path.join(self.location, "Scripts")
         else:
             return os.path.join(self.location, "bin")

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import os
-import platform
 import sys
 from unittest import mock
 


### PR DESCRIPTION
Also re-factoring unit tests to account for this change. This is a follow up to #100.

Also some minor editorializing (switch usage of `dir` to `dir_` as a variable name, shadowing builtins grumble grumble).