### PR TITLE
Travis CI: Add Python 3.7 to the testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ matrix:
     env: NOXSESSION="tests-3.5"
   - python: '3.6'
     env: NOXSESSION="tests-3.6"
-  # Travis does not support 3.7 yet.
-  # https://github.com/travis-ci/travis-ci/issues/9815
-  # - python: '3.7'
-  #   env: NOX_SESSION="tests-3.7"
+  - python: '3.7'
+    env: NOXSESSION="tests-3.7"
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+    sudo: required  # required for Python 3.7 (travis-ci/travis-ci#9069)
   - python: '3.6'
     env: NOXSESSION="docs"
 install:


### PR DESCRIPTION
Add Python 3.7 to the testing In alignment with travis-ci/travis-ci#9069