### PR TITLE
Documentation fixes, spelling, etc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ Breaking changes and other important notes:
 * Nox is now published as "nox" on PyPI. This means that Nox is installed via `pip install nox` instead of `nox-automation`. Since the new release makes so many breaking changes, we won't be updating the old `nox-automation` package.
 * Nox's configuration file is now called `noxfile.py` instead of `nox.py`.
 * Nox no longer supports Python 2.7. You can still create and run Python 2.7 sessions, but Nox itself must be installed using Python 3.5+.
-* Nox's behavior has been changed from *declarative*  to *imperative*. Session actions now run immediately. Existing code to setup session virtualenv, such as `session.interpreter` **will break**! Please consult the documention on how to use `@nox.session(python=[...])` to configure virtualenvs for sessions.
+* Nox's behavior has been changed from *declarative*  to *imperative*. Session actions now run immediately. Existing code to setup session virtualenv, such as `session.interpreter` **will break**! Please consult the documentation on how to use `@nox.session(python=[...])` to configure virtualenvs for sessions.
 * Nox now uses calver for releases.
 * Support for the legacy naming convention (for example, `session_tests`) has been removed.
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -144,7 +144,7 @@ Session arguments can be parametrized with the :func:`nox.parametrize` decorator
         session.install(f'django=={django}')
         session.run('py.test')
 
-When you run ``nox``, it will create a three distinct sessions::
+When you run ``nox``, it will create a two distinct sessions::
 
     $ nox
     nox > Running session tests(django='1.9')

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -160,7 +160,7 @@ class Session:
                 success_codes=[0, 5])
 
         :param env: A dictionary of environment variables to expose to the
-            command. By default, all evironment variables are passed.
+            command. By default, all environment variables are passed.
         :type env: dict or None
         :param bool silent: Silence command output, unless the command fails.
             ``False`` by default.

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -38,7 +38,7 @@ def load_nox_module(global_config):
     """
     try:
         # Save the absolute path to the Noxfile.
-        # This will innoculate it if nox changes paths because of an implicit
+        # This will inoculate it if nox changes paths because of an implicit
         # or explicit chdir (like the one below).
         global_config.noxfile = os.path.realpath(global_config.noxfile)
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -154,7 +154,7 @@ def test_create_interpreter(make_one):
 
 def test__resolved_interpreter_none(make_one):
     # Establish that the _resolved_interpreter method is a no-op if the
-    # interpeter is not set.
+    # interpreter is not set.
     venv, _ = make_one(interpreter=None)
     assert venv._resolved_interpreter == sys.executable
 


### PR DESCRIPTION
Found the spelling errors with `codespell` using the command: `codespell nox/ docs/ tests/ *.py *.md *.rst --quiet-level=2`. Not sure if you'd like to add this to CI but I can do that as part of this PR if desired.