### PR TITLE
Addition of run_by_default flag and nox.param()

### DIFF
--- a/nox/__init__.py
+++ b/nox/__init__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from nox._parametrize import parametrize_decorator as parametrize
+from nox._parametrize import param, parametrize_decorator as parametrize
 from nox.registry import session_decorator as session
 
-__all__ = ["parametrize", "session"]
+__all__ = ["param", "parametrize", "session"]

--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -68,7 +68,7 @@ def main():
         "-e",
         "--sessions",
         nargs="*",
-        default=_get_default_sessions(),
+        default=_get_session_from_env(),
         help="Which sessions to run, by default, all sessions will run.",
     )
     parser.add_argument(
@@ -96,7 +96,7 @@ def main():
         "--forcecolor",
         default=False,
         action="store_true",
-        help=("Force color output, even if stdout is not an interactive " "terminal."),
+        help="Force color output, even if stdout is not an interactive terminal.",
     )
     parser.add_argument(
         "posargs",
@@ -137,7 +137,7 @@ def main():
     sys.exit(exit_code)
 
 
-def _get_default_sessions():
+def _get_session_from_env():
     nox_env = os.environ.get("NOXSESSION")
     env_sessions = nox_env.split(",") if nox_env else None
     return env_sessions

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -145,6 +145,35 @@ class Manifest:
             x for x in self._queue if keyword_match(keywords, [x.signature or x.name])
         ]
 
+    def filter_by_default(self):
+        """Filters all gathered sessions by whether they are marked with
+        nox.session(..., run_by_default=True) or one of the parameters is
+        nox.param(..., run_by_default=True).
+
+        If a session is marked with run_by_default=False and no sessions are
+        marked with run_by_default=True then all unmarked sessions will be run.
+
+        If no session is marked with run_by_default then all sessions will be run.
+        """
+        default_false_session_found = False
+        default_none_sessions = []
+        default_true_sessions = []
+
+        for x in self._queue:
+            if x.run_by_default is None:
+                default_none_sessions.append(x)
+            elif x.run_by_default is False:
+                default_false_session_found = True
+            elif x.run_by_default is True:
+                default_true_sessions.append(x)
+            else:
+                raise ValueError()
+
+        if len(default_true_sessions):
+            self._queue = default_true_sessions
+        elif default_false_session_found:
+            self._queue = default_none_sessions
+
     def make_session(self, name, func):
         """Create a session object from the session function.
 

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -19,7 +19,9 @@ import functools
 _REGISTRY = collections.OrderedDict()
 
 
-def session_decorator(func=None, python=None, py=None, reuse_venv=None):
+def session_decorator(
+    func=None, python=None, py=None, reuse_venv=None, run_by_default=None
+):
     """Designate the decorated function as a session."""
     # If `func` is provided, then this is the decorator call with the function
     # being sent as part of the Python syntax (`@nox.session`).
@@ -30,7 +32,11 @@ def session_decorator(func=None, python=None, py=None, reuse_venv=None):
     # This is what makes the syntax with and without parentheses both work.
     if func is None:
         return functools.partial(
-            session_decorator, python=python, py=py, reuse_venv=reuse_venv
+            session_decorator,
+            python=python,
+            py=py,
+            reuse_venv=reuse_venv,
+            run_by_default=run_by_default,
         )
 
     if py is not None and python is not None:
@@ -44,6 +50,7 @@ def session_decorator(func=None, python=None, py=None, reuse_venv=None):
 
     func.python = python
     func.reuse_venv = reuse_venv
+    func.run_by_default = run_by_default
     _REGISTRY[func.__name__] = func
 
     return func

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -267,6 +267,10 @@ class SessionRunner:
             return first_line
         return None
 
+    @property
+    def run_by_default(self):
+        return self.func.run_by_default
+
     def __str__(self):
         return self.signature or self.name
 

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -84,6 +84,19 @@ def filter_manifest(manifest, global_config):
             the manifest otherwise (to be sent to the next task).
 
     """
+
+    # If there are no session explicitly given then we need to discover
+    # all the default sessions to execute. If any of the sessions have
+    # run_by_default=True then run those. If none have that flag set
+    # then run all sessions.
+    if not global_config.sessions:
+        try:
+            manifest.filter_by_default()
+        except ValueError as exc:
+            logger.error("Error while collecting sessions.")
+            logger.error(exc.args[0])
+            return 3
+
     # Filter by the name of any explicit sessions.
     # This can raise KeyError if a specified session does not exist;
     # log this if it happens.

--- a/tests/test__parametrize.py
+++ b/tests/test__parametrize.py
@@ -23,7 +23,7 @@ def test_parametrize_decorator_one():
 
     _parametrize.parametrize_decorator("abc", 1)(f)
 
-    assert f.parametrize == [{"abc": 1}]
+    assert [x.kwargs for x in f.parametrize] == [{"abc": 1}]
 
 
 def test_parametrize_decorator_one_with_args():
@@ -32,7 +32,7 @@ def test_parametrize_decorator_one_with_args():
 
     _parametrize.parametrize_decorator("abc", [1, 2, 3])(f)
 
-    assert f.parametrize == [{"abc": 1}, {"abc": 2}, {"abc": 3}]
+    assert [x.kwargs for x in f.parametrize] == [{"abc": 1}, {"abc": 2}, {"abc": 3}]
 
 
 def test_parametrize_decorator_multiple_args_as_list():
@@ -43,7 +43,7 @@ def test_parametrize_decorator_multiple_args_as_list():
         f
     )
 
-    assert f.parametrize == [
+    assert [x.kwargs for x in f.parametrize] == [
         {"abc": "a", "def": 1},
         {"abc": "b", "def": 2},
         {"abc": "c", "def": 3},
@@ -56,7 +56,7 @@ def test_parametrize_decorator_multiple_args_as_string():
 
     _parametrize.parametrize_decorator("abc, def", [("a", 1), ("b", 2), ("c", 3)])(f)
 
-    assert f.parametrize == [
+    assert [x.kwargs for x in f.parametrize] == [
         {"abc": "a", "def": 1},
         {"abc": "b", "def": 2},
         {"abc": "c", "def": 3},
@@ -70,7 +70,7 @@ def test_parametrize_decorator_stack():
     _parametrize.parametrize_decorator("abc", [1, 2, 3])(f)
     _parametrize.parametrize_decorator("def", ["a", "b"])(f)
 
-    assert f.parametrize == [
+    assert [x.kwargs for x in f.parametrize] == [
         {"abc": 1, "def": "a"},
         {"abc": 2, "def": "a"},
         {"abc": 3, "def": "a"},
@@ -87,7 +87,7 @@ def test_parametrize_decorator_multiple_and_stack():
     _parametrize.parametrize_decorator("abc, def", [(1, "a"), (2, "b")])(f)
     _parametrize.parametrize_decorator("foo", ["bar", "baz"])(f)
 
-    assert f.parametrize == [
+    assert [x.kwargs for x in f.parametrize] == [
         {"abc": 1, "def": "a", "foo": "bar"},
         {"abc": 2, "def": "b", "foo": "bar"},
         {"abc": 1, "def": "a", "foo": "baz"},
@@ -101,7 +101,11 @@ def test_generate_calls_simple():
     f.__name__ = "f"
     f.some_prop = 42
 
-    call_specs = [{"abc": 1}, {"abc": 2}, {"abc": 3}]
+    call_specs = [
+        _parametrize.CallSpec({"abc": 1}),
+        _parametrize.CallSpec({"abc": 2}),
+        _parametrize.CallSpec({"abc": 3}),
+    ]
 
     calls = _parametrize.generate_calls(f, call_specs)
 
@@ -129,9 +133,9 @@ def test_generate_calls_multiple_args():
     f.__name__ = "f"
 
     call_specs = [
-        {"abc": 1, "foo": "a"},
-        {"abc": 2, "foo": "b"},
-        {"abc": 3, "foo": "c"},
+        _parametrize.CallSpec({"abc": 1, "foo": "a"}),
+        _parametrize.CallSpec({"abc": 2, "foo": "b"}),
+        _parametrize.CallSpec({"abc": 3, "foo": "c"}),
     ]
 
     calls = _parametrize.generate_calls(f, call_specs)

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -35,6 +35,7 @@ def session_func():
 
 
 session_func.python = None
+session_func.run_by_default = None
 
 
 def test_load_nox_module():


### PR DESCRIPTION
Here's my initial implementation of allowing the following:

```python
import nox

@nox.session(run_by_default=True)
def test_default(session):
    pass

@nox.session
@nox.parametrize(["django", "param"], [("1.9", 1), nox.param("2.0", 2, run_by_default=True))
def test_django_versions(session, django, param):
    pass
```

Also adds the "reverse" of `run_by_default=True` by allowing the following:

```python
@nox.session
def is_default(session):
    pass

@nox.session(run_by_default=False)
def is_not_default(session):
    pass
```

Basically the logic is as follows:
1. If there's any sessions marked with `run_by_default=True`, run only those sessions.
2. Else if there's any sessions marked with `run_by_default=False`, then run all unmarked sessions. 
3. Otherwise run all sessions.

This implementation is following some suggestions within #40 but doesn't incorporate the `nox.options...` suggestion I've seen in an issue elsewhere.

Will require additional test cases and updates to documentation. I've tested it locally by modifying the existing `noxfile.py`. I was just wondering if this was the solution that looks good to everyone, it seemed a little heavy-handed when I was writing it so I'm open to suggestions! :)

Fixes #40