### PR TITLE
Skip sessions with missing interpreters

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -104,6 +104,14 @@ By default nox will continue to run all sessions even if one fails. You can use 
     nox --stop-on-first-error
 
 
+Failing sessions when the interpreter is missing
+------------------------------------------------
+
+By default, Nox will skip sessions where the Python interpreter can't be found. If you want Nox to mark these sessions as failed, you can use ``--error-on-missing-interpreters``::
+
+    nox --error-on-missing-interpreters
+
+
 Controlling color output
 ------------------------
 

--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -39,6 +39,7 @@ class GlobalConfig:
         self.list_sessions = args.list_sessions
         self.reuse_existing_virtualenvs = args.reuse_existing_virtualenvs
         self.stop_on_first_error = args.stop_on_first_error
+        self.error_on_missing_interpreters = args.error_on_missing_interpreters
         self.posargs = args.posargs
         self.report = args.report
 
@@ -81,7 +82,15 @@ def main():
         help="Re-use existing virtualenvs instead of recreating them.",
     )
     parser.add_argument(
-        "--stop-on-first-error", action="store_true", help="Stop after the first error."
+        "-x",
+        "--stop-on-first-error",
+        action="store_true",
+        help="Stop after the first error.",
+    )
+    parser.add_argument(
+        "--error-on-missing-interpreters",
+        action="store_true",
+        help="Error instead of skip if an interpreter can not be located.",
     )
     parser.add_argument(
         "--report", default=None, help="Output a report of all sessions."

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -357,7 +357,7 @@ class Result:
             return "was successful"
         status = self.status.name.lower()
         if self.reason:
-            return f"{status}: {self.reason}"
+            return "{}: {}".format(status, self.reason)
         else:
             return status
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -239,15 +239,11 @@ class Session:
 
     def error(self, *args, **kwargs):
         """Immediately aborts the session and optionally logs an error."""
-        if args or kwargs:
-            logger.error(*args, **kwargs)
-        raise _SessionQuit()
+        raise _SessionQuit(*args, **kwargs)
 
     def skip(self, *args, **kwargs):
         """Immediately skips the session and optionally logs a warning."""
-        if args or kwargs:
-            logger.warning(*args, **kwargs)
-        raise _SessionSkip()
+        raise _SessionSkip(*args, **kwargs)
 
 
 class SessionRunner:
@@ -304,11 +300,17 @@ class SessionRunner:
             # Nothing went wrong; return a success.
             return Result(self, Status.SUCCESS)
 
-        except _SessionQuit:
-            return Result(self, Status.ABORTED)
+        except nox.virtualenv.InterpreterNotFound as exc:
+            if self.global_config.error_on_missing_interpreters:
+                return Result(self, Status.FAILED, reason=str(exc))
+            else:
+                return Result(self, Status.SKIPPED, reason=str(exc))
 
-        except _SessionSkip:
-            return Result(self, Status.SKIPPED)
+        except _SessionQuit as exc:
+            return Result(self, Status.ABORTED, reason=str(exc))
+
+        except _SessionSkip as exc:
+            return Result(self, Status.SKIPPED, reason=str(exc))
 
         except nox.command.CommandFailed:
             return Result(self, Status.FAILED)
@@ -325,16 +327,18 @@ class SessionRunner:
 class Result:
     """An object representing the result of a session."""
 
-    def __init__(self, session, status):
+    def __init__(self, session, status, reason=None):
         """Initialize the Result object.
 
         Args:
             session (~nox.sessions.SessionRunner):
                 The session runner which ran.
             status (~nox.sessions.Status): The final result status.
+            reason (str): Additional info.
         """
         self.session = session
         self.status = status
+        self.reason = reason
 
     def __bool__(self):
         return self.status.value > 0
@@ -351,7 +355,11 @@ class Result:
         """
         if self.status == Status.SUCCESS:
             return "was successful"
-        return self.status.name.lower()
+        status = self.status.name.lower()
+        if self.reason:
+            return f"{status}: {self.reason}"
+        else:
+            return status
 
     def log(self, message):
         """Log a message using the appropriate log function.

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -33,7 +33,7 @@ _SYSTEM = platform.system()
 
 class InterpreterNotFound(EnvironmentError):
     def __init__(self, interpreter):
-        super().__init__(f"Python interpreter {interpreter} not found")
+        super().__init__("Python interpreter {} not found".format(interpreter))
         self.interpreter = interpreter
 
 

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -31,7 +31,7 @@ _BLACKLISTED_ENV_VARS = frozenset(
 _SYSTEM = platform.system()
 
 
-class InterpreterNotFound(EnvironmentError):
+class InterpreterNotFound(OSError):
     def __init__(self, interpreter):
         super().__init__("Python interpreter {} not found".format(interpreter))
         self.interpreter = interpreter

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -40,6 +40,7 @@ def test_global_config_constructor():
         list_sessions=False,
         reuse_existing_virtualenvs=True,
         stop_on_first_error=False,
+        error_on_missing_interpreters=True,
         posargs=["a", "b", "c"],
         report=None,
     )
@@ -53,6 +54,7 @@ def test_global_config_constructor():
     assert config.list_sessions is False
     assert config.reuse_existing_virtualenvs is True
     assert config.stop_on_first_error is False
+    assert config.error_on_missing_interpreters is True
     assert config.posargs == ["a", "b", "c"]
 
     args.posargs = ["--", "a", "b", "c"]


### PR DESCRIPTION
Note: This changes Nox's behavior. Previously, missing interpreters would cause a failed session. Now they just cause a warning. The previous behavior can be used via ``--error-on-missing-interpreters``.

Replaces #138 
Closes #136 
Releated #93