### PR TITLE
Warn when programs not in the virtualenv are used, allow erroring and silencing the warning.

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -145,6 +145,7 @@ The following options can be specified in the Noxfile:
 * ``nox.options.reuse_existing_virtualenvs`` is equivalent to specifying :ref:`--reuse-existing-virtualenvs <opt-reuse-existing-virtualenvs>`. You can force this off by specifying ``--no-reuse-existing-virtualenvs`` during invocation.
 * ``nox.options.stop_on_first_error`` is equivalent to specifying :ref:`--stop-on-first-error <opt-stop-on-first-error>`. You can force this off by specifying ``--no-stop-on-first-error`` during invocation.
 * ``nox.options.error_on_missing_interpreters`` is equivalent to specifying :ref:`--error-on-missing-interpreters <opt-error-on-missing-interpreters>`. You can force this off by specifying ``--no-error-on-missing-interpreters`` during invocation.
+* ``nox.options.error_on_external_run`` is equivalent to specifying :ref:`--error-on-external-run <opt-error-on-external-run>`. You can force this off by specifying ``--no-error-on-external-run`` during invocation.
 * ``nox.options.report`` is equivalent to specifying :ref:`--report <opt-report>`.
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -113,6 +113,17 @@ By default, Nox will skip sessions where the Python interpreter can't be found. 
 
 If the Noxfile sets ``nox.options.error_on_missing_interpreters``, you can override the Noxfile setting from the command line by using ``--no-error-on-missing-interpreters``.
 
+.. _opt-error-on-external-run:
+
+Disallowing external programs
+-----------------------------
+
+By default Nox will warn but ultimately allow you to run programs not installed in the session's virtualenv. You can use ``--error-on-external-run`` to make Nox fail the session if it uses any external program without explicitly passing ``external=True`` into :func:`session.run <nox.session.Session.run>`::
+
+    nox --error-on-external-run
+
+If the Noxfile sets ``nox.options.error_on_external_run``, you can override the Noxfile setting from the command line by using ``--no-error-on-external-run``.
+
 Specifying a different configuration file
 -----------------------------------------
 

--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -52,6 +52,8 @@ class GlobalConfig:
         self.no_stop_on_first_error = args.no_stop_on_first_error
         self.error_on_missing_interpreters = args.error_on_missing_interpreters
         self.no_error_on_missing_interpreters = args.no_error_on_missing_interpreters
+        self.error_on_external_run = args.error_on_external_run
+        self.no_error_on_external_run = args.no_error_on_external_run
         self.posargs = args.posargs
         self.report = args.report
 
@@ -88,6 +90,11 @@ class GlobalConfig:
             self.error_on_missing_interpreters,
             options.error_on_missing_interpreters,
             self.no_error_on_missing_interpreters,
+        )
+        self.error_on_external_run = _default_with_off_flag(
+            self.error_on_external_run,
+            options.error_on_external_run,
+            self.no_error_on_external_run,
         )
         self.report = self.report or options.report
 
@@ -185,6 +192,17 @@ def main():
         "--no-error-on-missing-interpreters",
         action="store_true",
         help="Disables --error-on-missing-interpreters if it is enabled in the Noxfile.",
+    )
+
+    secondary.add_argument(
+        "--error-on-external-run",
+        action="store_true",
+        help="Error if run() is used to execute a program that isn't installed in a session's virtualenv.",
+    )
+    secondary.add_argument(
+        "--no-error-on-external-run",
+        action="store_true",
+        help="Disables --error-on-external-run if it is enabled in the Noxfile.",
     )
 
     secondary.add_argument(

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -29,4 +29,5 @@ class options:
     reuse_existing_virtualenvs = False
     stop_on_first_error = False
     error_on_missing_interpreters = False
+    error_on_external_run = False
     report = None

--- a/nox/command.py
+++ b/nox/command.py
@@ -66,7 +66,16 @@ def _clean_env(env):
     return clean_env
 
 
-def run(args, *, env=None, silent=False, path=None, success_codes=None, log=True):
+def run(
+    args,
+    *,
+    env=None,
+    silent=False,
+    path=None,
+    success_codes=None,
+    log=True,
+    external=False
+):
     """Run a command-line program."""
 
     if success_codes is None:
@@ -79,6 +88,24 @@ def run(args, *, env=None, silent=False, path=None, success_codes=None, log=True
 
     if log:
         logger.info(full_cmd)
+
+        is_external_tool = path is not None and not cmd_path.startswith(path)
+        if is_external_tool:
+            if external == "error":
+                logger.error(
+                    "Error: {} is not installed into the virtualenv, it located at {}. "
+                    "Pass external=True into run() to explicitly allow this.".format(
+                        cmd, cmd_path
+                    )
+                )
+                raise CommandFailed("External program disallowed.")
+            elif external is False:
+                logger.warning(
+                    "Warning: {} is not installed into the virtualenv, it located at {}. This might cause issues! "
+                    "Pass external=True into run() to silence this message.".format(
+                        cmd, cmd_path
+                    )
+                )
 
     env = _clean_env(env)
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -62,7 +62,7 @@ def lint(session):
 @nox.session(python="3.6")
 def docs(session):
     """Build the documentation."""
-    session.run("rm", "-rf", "docs/_build")
+    session.run("rm", "-rf", "docs/_build", external=True)
     session.install("-r", "requirements-test.txt")
     session.install(".")
     session.cd("docs")

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import logging
 import os
 import sys
 from unittest import mock
@@ -92,6 +93,35 @@ def test_run_path_existent(tmpdir, monkeypatch):
         mock_command.return_value = (0, "")
         nox.command.run(["testexc"], silent=True, path=tmpdir.strpath)
         mock_command.assert_called_with([executable.strpath], env=None, silent=True)
+
+
+def test_run_external_warns(tmpdir, caplog):
+    caplog.set_level(logging.WARNING)
+
+    nox.command.run([PYTHON, "--version"], silent=True, path=tmpdir.strpath)
+
+    assert "external=True" in caplog.text
+
+
+def test_run_external_silences(tmpdir, caplog):
+    caplog.set_level(logging.WARNING)
+
+    nox.command.run(
+        [PYTHON, "--version"], silent=True, path=tmpdir.strpath, external=True
+    )
+
+    assert "external=True" not in caplog.text
+
+
+def test_run_external_raises(tmpdir, caplog):
+    caplog.set_level(logging.ERROR)
+
+    with pytest.raises(nox.command.CommandFailed):
+        nox.command.run(
+            [PYTHON, "--version"], silent=True, path=tmpdir.strpath, external="error"
+        )
+
+    assert "external=True" in caplog.text
 
 
 def test_exit_codes():

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -46,6 +46,8 @@ class TestGlobalConfig:
             no_stop_on_first_error=False,
             error_on_missing_interpreters=False,
             no_error_on_missing_interpreters=False,
+            error_on_external_run=False,
+            no_error_on_external_run=True,
             posargs=["a", "b", "c"],
             report=None,
         )


### PR DESCRIPTION
Add --warn-on-external-run flag and the "external" keyword arg to session.run.

Closes #130