### PR TITLE
Hide the python interpreter on sessions with only one

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -269,9 +269,9 @@ class Session:
 
 
 class SessionRunner:
-    def __init__(self, name, signature, func, global_config, manifest=None):
+    def __init__(self, name, signatures, func, global_config, manifest=None):
         self.name = name
-        self.signature = signature
+        self.signatures = signatures
         self.func = func
         self.global_config = global_config
         self.manifest = manifest
@@ -286,14 +286,14 @@ class SessionRunner:
         return None
 
     def __str__(self):
-        return self.signature or self.name
+        return self.signatures[0] if self.signatures else self.name
 
     def _create_venv(self):
         if self.func.python is False:
             self.venv = ProcessEnv()
             return
 
-        name = self.signature or self.name
+        name = str(self)
         path = _normalize_path(self.global_config.envdir, name)
         reuse_existing = (
             self.func.reuse_venv or self.global_config.reuse_existing_virtualenvs
@@ -304,8 +304,7 @@ class SessionRunner:
         self.venv.create()
 
     def execute(self):
-        session_friendly_name = self.signature or self.name
-        logger.warning("Running session {}".format(session_friendly_name))
+        logger.warning("Running session {}".format(self))
 
         try:
             # By default, nox should quietly change to the directory where
@@ -409,5 +408,5 @@ class Result:
             "name": self.session.name,
             "result": self.status.name.lower(),
             "result_code": self.status.value,
-            "signature": self.session.signature,
+            "signatures": self.session.signatures,
         }

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -137,12 +137,7 @@ def honor_list_request(manifest, global_config):
             output = "* {session}"
             if session.description is not None:
                 output += " -> {description}"
-            print(
-                output.format(
-                    session=session.signature or session.name,
-                    description=session.description,
-                )
-            )
+            print(output.format(session=session, description=session.description))
         return 0
     return manifest
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -60,7 +60,7 @@ class TestSession:
         func = mock.Mock(spec=["python"], python="3.7")
         runner = nox.sessions.SessionRunner(
             name="test",
-            signature="test",
+            signatures=["test"],
             func=func,
             global_config=argparse.Namespace(
                 posargs=mock.sentinel.posargs, error_on_external_run=False
@@ -174,7 +174,7 @@ class TestSession:
     def test_install(self):
         runner = nox.sessions.SessionRunner(
             name="test",
-            signature="test",
+            signatures=["test"],
             func=mock.sentinel.func,
             global_config=argparse.Namespace(posargs=mock.sentinel.posargs),
             manifest=mock.create_autospec(nox.manifest.Manifest),
@@ -253,7 +253,7 @@ class TestSessionRunner:
         func.reuse_venv = False
         runner = nox.sessions.SessionRunner(
             name="test",
-            signature="test(1, 2)",
+            signatures=["test(1, 2)"],
             func=func,
             global_config=argparse.Namespace(
                 noxfile=os.path.join(os.getcwd(), "noxfile.py"),
@@ -270,7 +270,7 @@ class TestSessionRunner:
         runner = self.make_runner()
 
         assert runner.name == "test"
-        assert runner.signature == "test(1, 2)"
+        assert runner.signatures == ["test(1, 2)"]
         assert runner.func is not None
         assert callable(runner.func)
         assert isinstance(runner.description, str)
@@ -486,7 +486,7 @@ class TestResult:
     def test__serialize(self):
         result = nox.sessions.Result(
             session=argparse.Namespace(
-                signature="siggy", name="namey", func=mock.Mock()
+                signatures=["siggy"], name="namey", func=mock.Mock()
             ),
             status=nox.sessions.Status.SUCCESS,
         )
@@ -494,4 +494,4 @@ class TestResult:
         assert answer["name"] == "namey"
         assert answer["result"] == "success"
         assert answer["result_code"] == 1
-        assert answer["signature"] == "siggy"
+        assert answer["signatures"] == ["siggy"]

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -219,7 +219,9 @@ def test_create_report():
     config = argparse.Namespace(report="/path/to/report")
     results = [
         sessions.Result(
-            session=argparse.Namespace(signature="foosig", name="foo", func=object()),
+            session=argparse.Namespace(
+                signatures=["foosig"], name="foo", func=object()
+            ),
             status=sessions.Status.SUCCESS,
         )
     ]
@@ -233,7 +235,7 @@ def test_create_report():
                     "sessions": [
                         {
                             "name": "foo",
-                            "signature": "foosig",
+                            "signatures": ["foosig"],
                             "result": "success",
                             "result_code": 1,
                             "args": {},


### PR DESCRIPTION
This also finally allows sessions to properly have multiple names.

Closes #118