### PR TITLE
Add --install-only flag to install dependencies without running anything

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -143,6 +143,42 @@ By default nox stores virtualenvs in ``./.nox``, however, you can change this us
     nox --envdir /tmp/.
 
 
+Skipping everything but install commands
+----------------------------------------
+
+There are a couple of cases where it makes sense to have Nox only run ``install`` commands, such as preparing an environment for offline testing or re-creating the same virtulenvs used for testing. You can use ``--install-only`` to skip ``run`` commands.
+
+For example, given this Noxfile:
+
+.. code-block:: python
+
+    @nox.session
+    def tests(session):
+        session.install("pytest")
+        session.install(".")
+        session.run("pytest")
+
+
+Running:
+
+.. code-block:: bash
+
+    nox --install-only
+
+
+Would run both ``install`` commands, but skip the ``run`` command::
+
+.. code-block:: plaintext
+
+
+    nox > Running session tests
+    nox > Creating virtualenv using python3.7 in ./.nox/tests
+    nox > pip install --upgrade pytest
+    nox > pip install --upgrade .
+    nox > Skipping pytest run, as --install-only is set.
+    nox > Session tests was successful.
+
+
 Controlling color output
 ------------------------
 

--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -54,8 +54,8 @@ class GlobalConfig:
         self.no_error_on_missing_interpreters = args.no_error_on_missing_interpreters
         self.error_on_external_run = args.error_on_external_run
         self.no_error_on_external_run = args.no_error_on_external_run
-        self.skip_pytest = args.skip_pytest
-        self.no_skip_pytest = args.no_skip_pytest
+        self.install_only = args.install_only
+        self.no_install_only = args.no_install_only
         self.posargs = args.posargs
         self.report = args.report
 
@@ -98,8 +98,8 @@ class GlobalConfig:
             options.error_on_external_run,
             self.no_error_on_external_run,
         )
-        self.skip_pytest = _default_with_off_flag(
-            self.skip_pytest, options.skip_pytest, self.no_skip_pytest
+        self.install_only = _default_with_off_flag(
+            self.install_only, options.install_only, self.no_install_only
         )
         self.report = self.report or options.report
 
@@ -211,14 +211,14 @@ def main():
     )
 
     secondary.add_argument(
-        "--skip-pytest",
+        "--install-only",
         action="store_true",
-        help="Skip invocations of the form session.run('py.test', ...) in the noxfile.",
+        help="Skip session.run invocations in the noxfile.",
     )
     secondary.add_argument(
-        "--no-skip-pytest",
+        "--no-install-only",
         action="store_true",
-        help="Disables --skip-pytest if it is enabled in the Noxfile.",
+        help="Disables --install-only if it is enabled in the Noxfile.",
     )
 
     secondary.add_argument(

--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -98,9 +98,6 @@ class GlobalConfig:
             options.error_on_external_run,
             self.no_error_on_external_run,
         )
-        self.install_only = _default_with_off_flag(
-            self.install_only, options.install_only, self.no_install_only
-        )
         self.report = self.report or options.report
 
 

--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -55,7 +55,6 @@ class GlobalConfig:
         self.error_on_external_run = args.error_on_external_run
         self.no_error_on_external_run = args.no_error_on_external_run
         self.install_only = args.install_only
-        self.no_install_only = args.no_install_only
         self.posargs = args.posargs
         self.report = args.report
 
@@ -211,11 +210,6 @@ def main():
         "--install-only",
         action="store_true",
         help="Skip session.run invocations in the Noxfile.",
-    )
-    secondary.add_argument(
-        "--no-install-only",
-        action="store_true",
-        help="Disables --install-only if it is enabled in the Noxfile.",
     )
 
     secondary.add_argument(

--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -54,6 +54,8 @@ class GlobalConfig:
         self.no_error_on_missing_interpreters = args.no_error_on_missing_interpreters
         self.error_on_external_run = args.error_on_external_run
         self.no_error_on_external_run = args.no_error_on_external_run
+        self.skip_pytest = args.skip_pytest
+        self.no_skip_pytest = args.no_skip_pytest
         self.posargs = args.posargs
         self.report = args.report
 
@@ -95,6 +97,9 @@ class GlobalConfig:
             self.error_on_external_run,
             options.error_on_external_run,
             self.no_error_on_external_run,
+        )
+        self.skip_pytest = _default_with_off_flag(
+            self.skip_pytest, options.skip_pytest, self.no_skip_pytest
         )
         self.report = self.report or options.report
 
@@ -203,6 +208,17 @@ def main():
         "--no-error-on-external-run",
         action="store_true",
         help="Disables --error-on-external-run if it is enabled in the Noxfile.",
+    )
+
+    secondary.add_argument(
+        "--skip-pytest",
+        action="store_true",
+        help="Skip invocations of the form session.run('py.test', ...) in the noxfile.",
+    )
+    secondary.add_argument(
+        "--no-skip-pytest",
+        action="store_true",
+        help="Disables --skip-pytest if it is enabled in the Noxfile.",
     )
 
     secondary.add_argument(

--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -213,7 +213,7 @@ def main():
     secondary.add_argument(
         "--install-only",
         action="store_true",
-        help="Skip session.run invocations in the noxfile.",
+        help="Skip session.run invocations in the Noxfile.",
     )
     secondary.add_argument(
         "--no-install-only",

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -30,4 +30,5 @@ class options:
     stop_on_first_error = False
     error_on_missing_interpreters = False
     error_on_external_run = False
+    skip_pytest = False
     report = None

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -30,5 +30,5 @@ class options:
     stop_on_first_error = False
     error_on_missing_interpreters = False
     error_on_external_run = False
-    skip_pytest = False
+    install_only = False
     report = None

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -25,9 +25,6 @@ from nox.logger import logger
 from nox.virtualenv import ProcessEnv, VirtualEnv
 
 
-PYTEST_COMMAND = "py.test"
-
-
 def _normalize_path(envdir, path):
     """Normalizes a string to be a "safe" filesystem path for a virtualenv."""
     if isinstance(path, bytes):
@@ -181,6 +178,7 @@ class Session:
             raise ValueError("At least one argument required to run().")
 
         if self._runner.global_config.install_only:
+            logger.info("Skipping {} run, as --install-only is set.".format(args[0]))
             return
 
         # Legacy support - run a function given.

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -180,6 +180,9 @@ class Session:
         if not args:
             raise ValueError("At least one argument required to run().")
 
+        if self._runner.global_config.install_only:
+            return
+
         # Legacy support - run a function given.
         if callable(args[0]):
             return self._run_func(args[0], args[1:], kwargs)
@@ -201,16 +204,7 @@ class Session:
             kwargs["external"] = True
 
         # Run a shell command.
-        if (
-            args
-            and args[0] == PYTEST_COMMAND
-            and self._runner.global_config.skip_pytest
-        ):
-            logger.info(
-                "Skipping {} run, as --skip-pytest is set.".format(PYTEST_COMMAND)
-            )
-        else:
-            return nox.command.run(args, env=env, path=self.bin, **kwargs)
+        return nox.command.run(args, env=env, path=self.bin, **kwargs)
 
     def install(self, *args, **kwargs):
         """Install invokes `pip`_ to install packages inside of the session's

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -83,7 +83,7 @@ class Session:
     def __dict__(self):
         """Attribute dictionary for object inspection.
 
-        This is needed because ``__slots__`` turns of ``__dict__`` by
+        This is needed because ``__slots__`` turns off ``__dict__`` by
         default. Unlike a typical object, modifying the result of this
         dictionary won't allow modification of the instance.
         """

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -25,6 +25,9 @@ from nox.logger import logger
 from nox.virtualenv import ProcessEnv, VirtualEnv
 
 
+PYTEST_COMMAND = "py.test"
+
+
 def _normalize_path(envdir, path):
     """Normalizes a string to be a "safe" filesystem path for a virtualenv."""
     if isinstance(path, bytes):
@@ -198,7 +201,16 @@ class Session:
             kwargs["external"] = True
 
         # Run a shell command.
-        return nox.command.run(args, env=env, path=self.bin, **kwargs)
+        if (
+            args
+            and args[0] == PYTEST_COMMAND
+            and self._runner.global_config.skip_pytest
+        ):
+            logger.info(
+                "Skipping {} run, as --skip-pytest is set.".format(PYTEST_COMMAND)
+            )
+        else:
+            return nox.command.run(args, env=env, path=self.bin, **kwargs)
 
     def install(self, *args, **kwargs):
         """Install invokes `pip`_ to install packages inside of the session's

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -181,6 +181,10 @@ class Session:
             logger.info("Skipping {} run, as --install-only is set.".format(args[0]))
             return
 
+        return self._run(*args, env=env, **kwargs)
+
+    def _run(self, *args, env=None, **kwargs):
+        """Like run(), except that it runs even if --install-only is provided."""
         # Legacy support - run a function given.
         if callable(args[0]):
             return self._run_func(args[0], args[1:], kwargs)
@@ -239,7 +243,7 @@ class Session:
         if "silent" not in kwargs:
             kwargs["silent"] = True
 
-        self.run("pip", "install", "--upgrade", *args, external="error", **kwargs)
+        self._run("pip", "install", "--upgrade", *args, external="error", **kwargs)
 
     def notify(self, target):
         """Place the given session at the end of the queue.

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -111,7 +111,6 @@ class TestGlobalConfig:
         assert config.reuse_existing_virtualenvs is True
         assert config.stop_on_first_error is True
         assert config.error_on_missing_interpreters is True
-        assert config.install_only is True
         assert config.report == "output.json"
 
     def test_merge_from_options_args_precedence(self):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -49,7 +49,6 @@ class TestGlobalConfig:
             error_on_external_run=False,
             no_error_on_external_run=True,
             install_only=False,
-            no_install_only=False,
             posargs=["a", "b", "c"],
             report=None,
         )
@@ -70,7 +69,6 @@ class TestGlobalConfig:
         assert config.error_on_missing_interpreters is False
         assert config.no_error_on_missing_interpreters is False
         assert config.install_only is False
-        assert config.no_install_only is False
         assert config.posargs == ["a", "b", "c"]
 
         args.posargs = ["--", "a", "b", "c"]
@@ -119,7 +117,6 @@ class TestGlobalConfig:
         args.no_reuse_existing_virtualenvs = True
         args.no_stop_on_first_error = True
         args.no_error_on_missing_interpreters = True
-        args.no_install_only = True
         args.report = "output.json"
         config = nox.__main__.GlobalConfig(args)
         original_values = vars(config).copy()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -48,6 +48,8 @@ class TestGlobalConfig:
             no_error_on_missing_interpreters=False,
             error_on_external_run=False,
             no_error_on_external_run=True,
+            skip_pytest=False,
+            no_skip_pytest=False,
             posargs=["a", "b", "c"],
             report=None,
         )
@@ -67,6 +69,8 @@ class TestGlobalConfig:
         assert config.no_stop_on_first_error is False
         assert config.error_on_missing_interpreters is False
         assert config.no_error_on_missing_interpreters is False
+        assert config.skip_pytest is False
+        assert config.no_skip_pytest is False
         assert config.posargs == ["a", "b", "c"]
 
         args.posargs = ["--", "a", "b", "c"]
@@ -96,6 +100,7 @@ class TestGlobalConfig:
         options.reuse_existing_virtualenvs = True
         options.stop_on_first_error = True
         options.error_on_missing_interpreters = True
+        options.skip_pytest = True
         options.report = "output.json"
 
         config.merge_from_options(options)
@@ -106,6 +111,7 @@ class TestGlobalConfig:
         assert config.reuse_existing_virtualenvs is True
         assert config.stop_on_first_error is True
         assert config.error_on_missing_interpreters is True
+        assert config.skip_pytest is True
         assert config.report == "output.json"
 
     def test_merge_from_options_args_precedence(self):
@@ -114,6 +120,7 @@ class TestGlobalConfig:
         args.no_reuse_existing_virtualenvs = True
         args.no_stop_on_first_error = True
         args.no_error_on_missing_interpreters = True
+        args.no_skip_pytest = True
         args.report = "output.json"
         config = nox.__main__.GlobalConfig(args)
         original_values = vars(config).copy()
@@ -123,6 +130,7 @@ class TestGlobalConfig:
         options.reuse_existing_virtualenvs = True
         options.stop_on_first_error = True
         options.error_on_missing_interpreters = True
+        options.skip_pytest = True
 
         config.merge_from_options(options)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -48,8 +48,8 @@ class TestGlobalConfig:
             no_error_on_missing_interpreters=False,
             error_on_external_run=False,
             no_error_on_external_run=True,
-            skip_pytest=False,
-            no_skip_pytest=False,
+            install_only=False,
+            no_install_only=False,
             posargs=["a", "b", "c"],
             report=None,
         )
@@ -69,8 +69,8 @@ class TestGlobalConfig:
         assert config.no_stop_on_first_error is False
         assert config.error_on_missing_interpreters is False
         assert config.no_error_on_missing_interpreters is False
-        assert config.skip_pytest is False
-        assert config.no_skip_pytest is False
+        assert config.install_only is False
+        assert config.no_install_only is False
         assert config.posargs == ["a", "b", "c"]
 
         args.posargs = ["--", "a", "b", "c"]
@@ -100,7 +100,7 @@ class TestGlobalConfig:
         options.reuse_existing_virtualenvs = True
         options.stop_on_first_error = True
         options.error_on_missing_interpreters = True
-        options.skip_pytest = True
+        options.install_only = True
         options.report = "output.json"
 
         config.merge_from_options(options)
@@ -111,7 +111,7 @@ class TestGlobalConfig:
         assert config.reuse_existing_virtualenvs is True
         assert config.stop_on_first_error is True
         assert config.error_on_missing_interpreters is True
-        assert config.skip_pytest is True
+        assert config.install_only is True
         assert config.report == "output.json"
 
     def test_merge_from_options_args_precedence(self):
@@ -120,7 +120,7 @@ class TestGlobalConfig:
         args.no_reuse_existing_virtualenvs = True
         args.no_stop_on_first_error = True
         args.no_error_on_missing_interpreters = True
-        args.no_skip_pytest = True
+        args.no_install_only = True
         args.report = "output.json"
         config = nox.__main__.GlobalConfig(args)
         original_values = vars(config).copy()
@@ -130,7 +130,7 @@ class TestGlobalConfig:
         options.reuse_existing_virtualenvs = True
         options.stop_on_first_error = True
         options.error_on_missing_interpreters = True
-        options.skip_pytest = True
+        options.install_only = True
 
         config.merge_from_options(options)
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -108,7 +108,7 @@ class TestGlobalConfig:
         assert config.error_on_missing_interpreters is True
         assert config.report == "output.json"
 
-    def test_merge_from_options_args_precendence(self):
+    def test_merge_from_options_args_precedence(self):
         args = self.make_args()
         args.sessions = ["1", "2"]
         args.no_reuse_existing_virtualenvs = True

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -133,7 +133,13 @@ class TestSession:
         session.install("spam")
         session.run("spam", "eggs")
 
-        run_mock.assert_called_once_with("pip", "install", "--upgrade", "spam")
+        run_mock.assert_called_once_with(
+            ("pip", "install", "--upgrade", "spam"),
+            env=mock.ANY,
+            external=mock.ANY,
+            path=mock.ANY,
+            silent=mock.ANY,
+        )
 
     def test_run_success(self):
         session, _ = self.make_session_and_runner()
@@ -210,7 +216,7 @@ class TestSession:
 
         session = SessionNoSlots(runner=runner)
 
-        with mock.patch.object(session, "run", autospec=True) as run:
+        with mock.patch.object(session, "_run", autospec=True) as run:
             session.install("requests", "urllib3")
             run.assert_called_once_with(
                 "pip",
@@ -238,7 +244,7 @@ class TestSession:
 
         session = SessionNoSlots(runner=runner)
 
-        with mock.patch.object(session, "run", autospec=True) as run:
+        with mock.patch.object(session, "_run", autospec=True) as run:
             session.install("requests", "urllib3", silent=False)
             run.assert_called_once_with(
                 "pip",

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -56,14 +56,16 @@ def test__normalize_path_give_up():
 
 
 class TestSession:
-    def make_session_and_runner(self, **extra_args):
+    def make_session_and_runner(self):
         func = mock.Mock(spec=["python"], python="3.7")
         runner = nox.sessions.SessionRunner(
             name="test",
             signatures=["test"],
             func=func,
             global_config=argparse.Namespace(
-                posargs=mock.sentinel.posargs, error_on_external_run=False, **extra_args
+                posargs=mock.sentinel.posargs,
+                error_on_external_run=False,
+                install_only=False,
             ),
             manifest=mock.create_autospec(nox.manifest.Manifest),
         )
@@ -115,9 +117,10 @@ class TestSession:
     @mock.patch.object(nox.command, "run")
     @mock.patch.object(logger, "info")
     def test_run_install_only(self, log_info, run_mock):
-        session, _ = self.make_session_and_runner(install_only=True)
+        session, runner = self.make_session_and_runner()
+        runner.global_config.install_only = True
 
-        session.run("py.test", "foo")
+        session.run("spam", "eggs")
 
         run_mock.assert_not_called()
         log_info.assert_called_once_with(mock.ANY)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -114,26 +114,27 @@ class TestSession:
         with pytest.raises(nox.command.CommandFailed):
             assert session.run(raise_value_error)
 
-    @mock.patch.object(nox.command, "run")
-    @mock.patch.object(logger, "info")
-    def test_run_install_only(self, log_info, run_mock):
+    def test_run_install_only(self, caplog):
+        caplog.set_level(logging.INFO)
         session, runner = self.make_session_and_runner()
         runner.global_config.install_only = True
 
-        session.run("spam", "eggs")
+        with mock.patch.object(nox.command, "run") as run:
+            session.run("spam", "eggs")
 
-        run_mock.assert_not_called()
-        log_info.assert_called_once_with(mock.ANY)
+        run.assert_not_called()
 
-    @mock.patch.object(nox.command, "run")
-    def test_run_install_only_should_install(self, run_mock):
+        assert "install-only" in caplog.text
+
+    def test_run_install_only_should_install(self):
         session, runner = self.make_session_and_runner()
         runner.global_config.install_only = True
 
-        session.install("spam")
-        session.run("spam", "eggs")
+        with mock.patch.object(nox.command, "run") as run:
+            session.install("spam")
+            session.run("spam", "eggs")
 
-        run_mock.assert_called_once_with(
+        run.assert_called_once_with(
             ("pip", "install", "--upgrade", "spam"),
             env=mock.ANY,
             external=mock.ANY,

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -114,8 +114,8 @@ class TestSession:
 
     @mock.patch.object(nox.command, "run")
     @mock.patch.object(logger, "info")
-    def test_run_skip_pytest(self, log_info, run_mock):
-        session, _ = self.make_session_and_runner(skip_pytest=True)
+    def test_run_install_only(self, log_info, run_mock):
+        session, _ = self.make_session_and_runner(install_only=True)
 
         session.run("py.test", "foo")
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -125,6 +125,16 @@ class TestSession:
         run_mock.assert_not_called()
         log_info.assert_called_once_with(mock.ANY)
 
+    @mock.patch.object(nox.command, "run")
+    def test_run_install_only_should_install(self, run_mock):
+        session, runner = self.make_session_and_runner()
+        runner.global_config.install_only = True
+
+        session.install("spam")
+        session.run("spam", "eggs")
+
+        run_mock.assert_called_once_with("pip", "install", "--upgrade", "spam")
+
     def test_run_success(self):
         session, _ = self.make_session_and_runner()
         result = session.run(sys.executable, "-c", "print(123)")


### PR DESCRIPTION
The main use is for downloading dependencies for later offline use (with `--reuse-existing-virtualenvs`). A typical session where this would be useful will have the form:

```python
@nox.session
def tests(session):
    session.install(...)
    session.run("spam", ...)
```