### PR TITLE
Allow silent argument to be set in session.install

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -232,15 +232,10 @@ class Session:
         if not args:
             raise ValueError("At least one argument required to install().")
 
-        self.run(
-            "pip",
-            "install",
-            "--upgrade",
-            *args,
-            silent=True,
-            external="error",
-            **kwargs
-        )
+        if "silent" not in kwargs:
+            kwargs["silent"] = True
+
+        self.run("pip", "install", "--upgrade", *args, external="error", **kwargs)
 
     def notify(self, target):
         """Place the given session at the end of the queue.

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -199,6 +199,34 @@ class TestSession:
                 external="error",
             )
 
+    def test_install_non_default_kwargs(self):
+        runner = nox.sessions.SessionRunner(
+            name="test",
+            signatures=["test"],
+            func=mock.sentinel.func,
+            global_config=argparse.Namespace(posargs=mock.sentinel.posargs),
+            manifest=mock.create_autospec(nox.manifest.Manifest),
+        )
+        runner.venv = mock.create_autospec(nox.virtualenv.VirtualEnv)
+        runner.venv.env = {}
+
+        class SessionNoSlots(nox.sessions.Session):
+            pass
+
+        session = SessionNoSlots(runner=runner)
+
+        with mock.patch.object(session, "run", autospec=True) as run:
+            session.install("requests", "urllib3", silent=False)
+            run.assert_called_once_with(
+                "pip",
+                "install",
+                "--upgrade",
+                "requests",
+                "urllib3",
+                silent=False,
+                external="error",
+            )
+
     def test_notify(self):
         session, runner = self.make_session_and_runner()
 


### PR DESCRIPTION
Addresses #156 by checking if `silent` is in the kwargs passed to `session.install()`. If not, it sets it to the default True.