### PR TITLE
Don't colour output if `NO_COLOR` is set

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -184,7 +184,8 @@ Controlling color output
 
 By default, Nox will output colorful logs if you're using in an interactive
 terminal. However, if you are redirecting ``stderr`` to a file or otherwise
-not using an interactive terminal, nox will output in plaintext.
+not using an interactive terminal, or the environment variable ``NO_COLOR`` is
+set, nox will output in plaintext.
 
 You can manually control Nox's output using the ``--nocolor`` and ``--forcecolor`` flags.
 

--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -218,7 +218,7 @@ def main():
 
     secondary.add_argument(
         "--nocolor",
-        default=not sys.stderr.isatty(),
+        default="NO_COLOR" in os.environ or not sys.stderr.isatty(),
         action="store_true",
         help="Disable all color output.",
     )


### PR DESCRIPTION
This follows the informal standard defined at https://no-color.org, allowing users who don't want colour output from command line applications to set a single environment variable to disable it in all supported applications.