### PR TITLE
Allow providing a friendlier CLI name to sessions.

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -37,13 +37,42 @@ The first line will be shown when listing the sessions. For example::
         """Run the test suite."""
         session.run('pytest')
 
-The ``nox -l`` command will show:
+The ``nox --list`` command will show:
 
 .. code-block:: console
 
-    $ nox -l
+    $ nox --list
     Available sessions:
     * tests -> Run the test suite.
+
+
+Session name
+------------
+
+By default Nox uses the decorated function's name as the session name. This works wonderfully for the vast majority of projects, however, if you need to you can customize the session's name by using the ``name`` argument to ``@nox.session``. For example::
+
+
+    import nox
+
+    @nox.session(name="custom-name")
+    def a_very_long_function_name(session):
+        print("Hello!")
+
+
+The ``nox --list`` command will show:
+
+.. code-block:: console
+
+    $ nox --list
+    Available sessions:
+    * custom-name
+
+And you can tell ``nox`` to run the session using the custom name:
+
+.. code-block:: console
+
+    $ nox --session "custom-name"
+    Hello!
 
 .. _virtualenv config:
 
@@ -70,13 +99,15 @@ When you provide a version number, Nox automatically prepends python to determin
     def tests(session):
         pass
 
-When collecting your sessions, Nox will create a separate session for each interpreter. You can see these sesions when running ``nox --list-sessions``. For example this Noxfile::
+When collecting your sessions, Nox will create a separate session for each interpreter. You can see these sesions when running ``nox --list``. For example this Noxfile::
 
     @nox.session(python=['2.7', '3.5', '3.6', '3.7'])
     def tests(session):
         pass
 
-Will produce these sessions::
+Will produce these sessions:
+
+.. code-block:: console
 
     * tests-2.7
     * tests-3.5

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -19,7 +19,7 @@ import functools
 _REGISTRY = collections.OrderedDict()
 
 
-def session_decorator(func=None, python=None, py=None, reuse_venv=None):
+def session_decorator(func=None, python=None, py=None, reuse_venv=None, name=None):
     """Designate the decorated function as a session."""
     # If `func` is provided, then this is the decorator call with the function
     # being sent as part of the Python syntax (`@nox.session`).
@@ -30,7 +30,7 @@ def session_decorator(func=None, python=None, py=None, reuse_venv=None):
     # This is what makes the syntax with and without parentheses both work.
     if func is None:
         return functools.partial(
-            session_decorator, python=python, py=py, reuse_venv=reuse_venv
+            session_decorator, python=python, py=py, reuse_venv=reuse_venv, name=name
         )
 
     if py is not None and python is not None:
@@ -44,7 +44,7 @@ def session_decorator(func=None, python=None, py=None, reuse_venv=None):
 
     func.python = python
     func.reuse_venv = reuse_venv
-    _REGISTRY[func.__name__] = func
+    _REGISTRY[name or func.__name__] = func
 
     return func
 

--- a/tests/resources/noxfile_spaces.py
+++ b/tests/resources/noxfile_spaces.py
@@ -1,0 +1,21 @@
+# Copyright 2018 Alethea Katherine Flowers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nox
+
+
+@nox.session(py=False, name="cheese list")
+@nox.parametrize("cheese", ["cheddar", "jack", "brie"])
+def snack(unused_session, cheese):
+    print("Noms, {} so good!".format(cheese))

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -221,6 +221,22 @@ def test_main_explicit_sessions():
         assert config.sessions == ["1", "2"]
 
 
+def test_main_explicit_sessions_with_spaces_in_names():
+    sys.argv = [sys.executable, "-e", "unit tests", "the unit tests"]
+    with mock.patch("nox.workflow.execute") as execute:
+        execute.return_value = 0
+
+        # Call the main function.
+        with mock.patch.object(sys, "exit") as exit:
+            nox.__main__.main()
+            exit.assert_called_once_with(0)
+        assert execute.called
+
+        # Verify that the explicit sessions are listed in the config.
+        config = execute.call_args[1]["global_config"]
+        assert config.sessions == ["unit tests", "the unit tests"]
+
+
 @pytest.mark.parametrize(
     "env,sessions", [("foo", ["foo"]), ("foo,bar", ["foo", "bar"])]
 )
@@ -340,4 +356,21 @@ def test_main_nested_config(capsys):
         stdout, stderr = capsys.readouterr()
         assert stdout == "Noms, cheddar so good!\n"
         assert "Session snack(cheese='cheddar') was successful." in stderr
+        sys_exit.assert_called_once_with(0)
+
+
+def test_main_session_with_names(capsys):
+    sys.argv = [
+        "nox",
+        "--noxfile",
+        os.path.join(RESOURCES, "noxfile_spaces.py"),
+        "-s",
+        "cheese list(cheese='cheddar')",
+    ]
+
+    with mock.patch("sys.exit") as sys_exit:
+        nox.__main__.main()
+        stdout, stderr = capsys.readouterr()
+        assert stdout == "Noms, cheddar so good!\n"
+        assert "Session cheese list(cheese='cheddar') was successful." in stderr
         sys_exit.assert_called_once_with(0)

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -82,15 +82,16 @@ def test_session_decorator_reuse(cleanup_registry):
     assert unit_tests.reuse_venv is True
 
 
-def test_session_decorator_name(cleanup_registry):
-    @registry.session_decorator(name="unit-tests")
+@pytest.mark.parametrize("name", ["unit-tests", "unit tests", "the unit tests"])
+def test_session_decorator_name(cleanup_registry, name):
+    @registry.session_decorator(name=name)
     def unit_tests(session):
         pass
 
     answer = registry.get()
     assert "unit_tests" not in answer
-    assert "unit-tests" in answer
-    assert answer["unit-tests"] is unit_tests
+    assert name in answer
+    assert answer[name] is unit_tests
     assert unit_tests.python is None
 
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -82,6 +82,18 @@ def test_session_decorator_reuse(cleanup_registry):
     assert unit_tests.reuse_venv is True
 
 
+def test_session_decorator_name(cleanup_registry):
+    @registry.session_decorator(name="unit-tests")
+    def unit_tests(session):
+        pass
+
+    answer = registry.get()
+    assert "unit_tests" not in answer
+    assert "unit-tests" in answer
+    assert answer["unit-tests"] is unit_tests
+    assert unit_tests.python is None
+
+
 def test_get(cleanup_registry):
     # Establish that the get method returns a copy of the registry.
     empty = registry.get()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -73,6 +73,10 @@ def test_discover_session_functions_decorator():
     def bar():
         pass
 
+    @nox.session(name="not-a-bar")
+    def not_a_bar():
+        pass
+
     def notasession():
         pass
 
@@ -85,8 +89,8 @@ def test_discover_session_functions_decorator():
     # Get the manifest and establish that it looks like what we expect.
     manifest = tasks.discover_manifest(mock_module, config)
     sessions = list(manifest)
-    assert [s.func for s in sessions] == [foo, bar]
-    assert [i.friendly_name for i in sessions] == ["foo", "bar"]
+    assert [s.func for s in sessions] == [foo, bar, not_a_bar]
+    assert [i.friendly_name for i in sessions] == ["foo", "bar", "not-a-bar"]
 
 
 def test_filter_manifest():


### PR DESCRIPTION
```python
import nox

@nox.session
def a_bar(session):
    pass

@nox.session(name="not-a-bar")
def not_a_bar(session):
    pass
```

```
$ nox -l
Available sessions:
* a_bar
* not-a-bar
```