### PR TITLE
Expand environment variables when loading the noxfile from provided path

### DIFF
--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -41,7 +41,10 @@ def load_nox_module(global_config):
         # Save the absolute path to the Noxfile.
         # This will inoculate it if nox changes paths because of an implicit
         # or explicit chdir (like the one below).
-        global_config.noxfile = os.path.realpath(global_config.noxfile)
+        global_config.noxfile = os.path.realpath(
+            # Be sure to expand variables
+            os.path.expandvars(global_config.noxfile)
+        )
 
         # Move to the path where the Noxfile is.
         # This will ensure that the Noxfile's path is on sys.path, and that

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -400,7 +400,7 @@ class TestSessionRunner:
 
         create.assert_called_once_with(runner.venv)
         assert isinstance(runner.venv, nox.virtualenv.VirtualEnv)
-        assert runner.venv.interpreter is "coolpython"
+        assert runner.venv.interpreter == "coolpython"
         assert runner.venv.reuse_existing is True
 
     def make_runner_with_mock_venv(self):

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -54,7 +54,7 @@ def test_constructor_defaults(make_one):
 def test_constructor_explicit(make_one):
     venv, _ = make_one(interpreter="python3.5", reuse_existing=True)
     assert venv.location
-    assert venv.interpreter is "python3.5"
+    assert venv.interpreter == "python3.5"
     assert venv.reuse_existing is True
 
 


### PR DESCRIPTION
Our CI setup uploads the repo to the system's temporary directory, which on Linux is known(or commonly enough `/tmp`) but on windows, `%TEMP%` is used:
```
❯ bundle exec kitchen verify py3-windows-2012r2
-----> Starting Kitchen (v1.23.5)
-----> Verifying <py3-windows-2012r2>...
       [Nox] Verify on instance py3-windows-2012r2 with state={:username=>"administrator", :auto_security_group_id=>"sg-0cf1cc52c2d0e5d24", :server_id=>"i-0f2b90b1cfedb970e", :hostname=>"10.27.2.213", :password=>"uDU9*;ZH(j", :last_action=
>"verify", :last_error=>nil}
       Running Command: nox -f %TEMP%\kitchen/testing/noxfile.py -e "runtests-3(coverage=True)" -- --output-columns=120 --sysinfo --xml=%TEMP%\kitchen/testing/artifacts/xml-unittests-output --names-file=%TEMP%\kitchen\testing\tests\whiteli
st.txt --transport=zeromq -v --run-destructive --ssh-tests    -n tests\unit 2>&1
       nox : Noxfile C:\Users\Administrator\Documents\%TEMP%\kitchen\testing\noxfile.py not found.
       At line:1 char:1
       + nox -f %TEMP%\kitchen/testing/noxfile.py -e "runtests-3(coverage=True)" -- --out ...
       + ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
           + CategoryInfo          : NotSpecified: (Noxfile C:\User...e.py not found.:String) [], RemoteException
           + FullyQualifiedErrorId : NativeCommandError
        
       Verify command failed :: WinRM exited (2) for command: [nox -f %TEMP%\kitchen/testing/noxfile.py -e "runtests-3(coverage=True)" -- --output-columns=120 --sysinfo --xml=%TEMP%\kitchen/testing/artifacts/xml-unittests-output --names-fi
le=%TEMP%\kitchen\testing\tests\whitelist.txt --transport=zeromq -v --run-destructive --ssh-tests    -n tests\unit 2>&1]                                                                                                                      
       Copying %TEMP%\kitchen/testing/artifacts to /home/vampas/projects/SaltStack/salt/features/nox-2017.7/
       Copying c:/salt/var/log/salt/minion to artifacts/logs/minion
>>>>>> Failed to copy c:/salt/var/log/salt/minion to artifacts/logs/minion :: ${e}
       Finished verifying <py3-windows-2012r2> (0m14.00s).
-----> Kitchen is finished. (0m16.95s)
```
This PR processes the passed `noxfile` through `os.path.expandvars` to accommodate the above scenario.