### PR TITLE
Allow not passing "--upgrade" to `session.install`

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -46,7 +46,7 @@ If you run this via ``nox`` you should see output similar to this::
 
     nox > Running session lint
     nox > virtualenv /tmp/example/.nox/lint
-    nox > pip install --upgrade flake8
+    nox > pip install flake8
     nox > flake8
     nox > Session lint successful. :)
 
@@ -149,10 +149,10 @@ When you run ``nox``, it will create a two distinct sessions::
 
     $ nox
     nox > Running session tests(django='1.9')
-    nox > pip install --upgrade django==1.9
+    nox > pip install django==1.9
     ...
     nox > Running session tests(djano='2.0')
-    nox > pip install --upgrade django==2.0
+    nox > pip install django==2.0
 
 
 :func:`nox.parametrize` has an interface and usage intentionally similar to `pytest's parametrize <https://pytest.org/latest/parametrize.html#_pytest.python.Metafunc.parametrize>`_.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -173,8 +173,8 @@ Would run both ``install`` commands, but skip the ``run`` command::
 
     nox > Running session tests
     nox > Creating virtualenv using python3.7 in ./.nox/tests
-    nox > pip install --upgrade pytest
-    nox > pip install --upgrade .
+    nox > pip install pytest
+    nox > pip install .
     nox > Skipping pytest run, as --install-only is set.
     nox > Session tests was successful.
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -243,7 +243,7 @@ class Session:
         if "silent" not in kwargs:
             kwargs["silent"] = True
 
-        self._run("pip", "install", "--upgrade", *args, external="error", **kwargs)
+        self._run("pip", "install", *args, external="error", **kwargs)
 
     def notify(self, target):
         """Place the given session at the end of the queue.

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -135,7 +135,7 @@ class TestSession:
             session.run("spam", "eggs")
 
         run.assert_called_once_with(
-            ("pip", "install", "--upgrade", "spam"),
+            ("pip", "install", "spam"),
             env=mock.ANY,
             external=mock.ANY,
             path=mock.ANY,
@@ -220,13 +220,7 @@ class TestSession:
         with mock.patch.object(session, "_run", autospec=True) as run:
             session.install("requests", "urllib3")
             run.assert_called_once_with(
-                "pip",
-                "install",
-                "--upgrade",
-                "requests",
-                "urllib3",
-                silent=True,
-                external="error",
+                "pip", "install", "requests", "urllib3", silent=True, external="error"
             )
 
     def test_install_non_default_kwargs(self):
@@ -248,13 +242,7 @@ class TestSession:
         with mock.patch.object(session, "_run", autospec=True) as run:
             session.install("requests", "urllib3", silent=False)
             run.assert_called_once_with(
-                "pip",
-                "install",
-                "--upgrade",
-                "requests",
-                "urllib3",
-                silent=False,
-                external="error",
+                "pip", "install", "requests", "urllib3", silent=False, external="error"
             )
 
     def test_notify(self):


### PR DESCRIPTION
I don't really know the reasoning why `--upgrade` was added by default to the `pip` call in `session.install`.
I would reason against it, but, since it has been the default, at least allow the user not to upgrade.