### PR TITLE
Fix documentation link for Docker Cloud vs Hub

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -180,5 +180,5 @@ If you only want to run one of the parametrized sessions, see :ref:`running_para
 
 .. _pip: https://pip.readthedocs.org
 .. _flake8: https://flake8.readthedocs.org
-.. _thekevjames/nox images: https://cloud.docker.com/repository/docker/thekevjames/nox
+.. _thekevjames/nox images: https://hub.docker.com/r/thekevjames/nox
 .. _virtualenv: https://virtualenv.readthedocs.org


### PR DESCRIPTION
Looks like Docker changed some links around and the old link is now only available when logged in. Changed the link to something which should work even for users without DockerHub accounts.