### PR TITLE
Fix funding external link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
 # These are supported funding model platforms
 
-open_collective: https://opencollective.com/python-nox
+open_collective: python-nox


### PR DESCRIPTION
The open collective key accepts a username.

Current URL looks like: https://opencollective.com/https://opencollective.com/python-nox