### PR TITLE
Replace imp.load_source() with importlib (#212)

### DIFF
--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import imp
+import importlib
 import io
 import json
 import os
@@ -54,7 +54,10 @@ def load_nox_module(global_config):
         # import-time path resolutions work the way the Noxfile author would
         # guess.
         os.chdir(os.path.realpath(os.path.dirname(global_config.noxfile)))
-        return imp.load_source("user_nox_module", global_config.noxfile)
+        return importlib.machinery.SourceFileLoader(
+            "user_nox_module", global_config.noxfile
+        ).load_module()
+
     except (IOError, OSError):
         logger.error("Noxfile {} not found.".format(global_config.noxfile))
         return 2


### PR DESCRIPTION
Closes #212.

Python 3 deprecated imp.load_source and the entire imp package
has been deprecated since 3.4.

Same functionality served by importlib.machinery.SourceFileLoader,
see Brett Cannon back in 2012: https://bugs.python.org/issue14551
The load_module method provides a drop-in replacement for
load_source.