### PR TITLE
Add `session(venv_backend='conda')` option to use Conda environments.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,11 +17,11 @@ matrix:
 before_install:
   # Only test with conda on one test session.
   - if [ ${NOXSESSION} == "tests-3.7" ] then
-      wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+      wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
       chmod +x miniconda.sh
       ./miniconda.sh -b
       # Prefer the built-in python binary.
-      export PATH="$PATH:/home/travis/miniconda/bin"
+      export PATH="$PATH:/home/travis/miniconda3/bin"
       conda update --yes conda
     fi
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,16 @@ matrix:
   - python: '3.7'
     env: NOXSESSION="docs"
     dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+before_install:
+  # Only test with conda on one test session.
+  - if [ ${NOXSESSION} == "tests-3.7" ] then
+      wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+      chmod +x miniconda.sh
+      ./miniconda.sh -b
+      # Prefer the built-in python binary.
+      export PATH="$PATH:/home/travis/miniconda/bin"
+      conda update --yes conda
+    fi
 install:
   - pip install --upgrade pip setuptools
   - pip install .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,8 +19,7 @@ environment:
       NOX_SESSION: "tests-3.5"
 
     - PYTHON: "C:\\Python36"
-      # No 32-bit version of pip for Python 3.6 on conda-forge.
-      CONDA: "C:\\Miniconda36-x64"
+      CONDA: "C:\\Miniconda36"
       NOX_SESSION: "tests-3.6"
 
     - PYTHON: "C:\\Python36-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,7 +39,7 @@ install:
   # https://www.tjelvarolsson.com/blog/how-to-continuously-test-your-python-code-on-windows-using-appveyor/
   - "SET PATH=%CONDA%;%CONDA%\\Scripts;%PATH%"
   - conda config --set changeps1 no
-  - conda update -q conda
+  - conda update -q --yes conda
   # Get Python from conda-forge.
   - conda config --add channels conda-forge
   - conda config --set channel_priority strict

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,8 +27,12 @@ environment:
 
     - PYTHON: "C:\\Python37-x64"
       NOX_SESSION: "tests-3.7"
+      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 install:
+  # Activate the conda command, if desired.
+  - cmd: IF [%CONDA_INSTALL_LOCN] NEQ [] call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
+
   # Prepend newly installed Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart
   # the parent CMD process).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,12 +27,8 @@ environment:
 
     - PYTHON: "C:\\Python37-x64"
       NOX_SESSION: "tests-3.7"
-      CONDA_INSTALL_LOCN: C:\Miniconda36-x64
 
 install:
-  # Activate the conda command, if desired.
-  - cmd: IF [%CONDA_INSTALL_LOCN] NEQ [] call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-
   # Prepend newly installed Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart
   # the parent CMD process).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,8 @@ environment:
       NOX_SESSION: "tests-3.6"
 
     - PYTHON: "C:\\Python37"
-      CONDA: "C:\\Miniconda37"
+      # No 32-bit version of Python 3.7 on conda-forge.
+      CONDA: "C:\\Miniconda37-x64"
       NOX_SESSION: "tests-3.7"
 
     - PYTHON: "C:\\Python37-x64"
@@ -37,8 +38,11 @@ install:
   # Add conda command to path.
   # https://www.tjelvarolsson.com/blog/how-to-continuously-test-your-python-code-on-windows-using-appveyor/
   - "SET PATH=%CONDA%;%CONDA%\\Scripts;%PATH%"
-  - conda config --set always_yes yes --set changeps1 no
+  - conda config --set changeps1 no
   - conda update -q conda
+  # Get Python from conda-forge.
+  - conda config --add channels conda-forge
+  - conda config --set channel_priority strict
   - conda info -a
 
   # Prepend newly installed Python to the PATH of this build (this cannot be

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,6 @@ install:
   - conda update -q --yes conda
   # Get Python from conda-forge.
   - conda config --add channels conda-forge
-  - conda config --set channel_priority strict
   - conda info -a
 
   # Prepend newly installed Python to the PATH of this build (this cannot be

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,8 +11,7 @@ environment:
     # See: http://www.appveyor.com/docs/installed-software#python
 
     - PYTHON: "C:\\Python35"
-      # 32-bit Python not available with miniconda.
-      CONDA: "C:\\Miniconda35-x64"
+      CONDA: "C:\\Miniconda35"
       NOX_SESSION: "tests-3.5"
 
     - PYTHON: "C:\\Python35-x64"
@@ -20,16 +19,14 @@ environment:
       NOX_SESSION: "tests-3.5"
 
     - PYTHON: "C:\\Python36"
-      # 32-bit Python not available with miniconda.
-      CONDA: "C:\\Miniconda36-x64"
+      CONDA: "C:\\Miniconda36"
       NOX_SESSION: "tests-3.6"
 
     - PYTHON: "C:\\Python36-x64"
       NOX_SESSION: "tests-3.6"
 
     - PYTHON: "C:\\Python37"
-      # 32-bit Python not available with miniconda.
-      CONDA: "C:\\Miniconda37-x64"
+      CONDA: "C:\\Miniconda37"
       NOX_SESSION: "tests-3.7"
 
     - PYTHON: "C:\\Python37-x64"
@@ -38,7 +35,11 @@ environment:
 
 install:
   # Add conda command to path.
+  # https://www.tjelvarolsson.com/blog/how-to-continuously-test-your-python-code-on-windows-using-appveyor/
   - "SET PATH=%CONDA%;%CONDA%\\Scripts;%PATH%"
+  - conda config --set always_yes yes --set changeps1 no
+  - conda update -q conda
+  - conda info -a
 
   # Prepend newly installed Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,24 +11,33 @@ environment:
     # See: http://www.appveyor.com/docs/installed-software#python
 
     - PYTHON: "C:\\Python35"
+      CONDA: "C:\\Miniconda35"
       NOX_SESSION: "tests-3.5"
 
     - PYTHON: "C:\\Python35-x64"
+      CONDA: "C:\\Miniconda35-x64"
       NOX_SESSION: "tests-3.5"
 
     - PYTHON: "C:\\Python36"
+      CONDA: "C:\\Miniconda36"
       NOX_SESSION: "tests-3.6"
 
     - PYTHON: "C:\\Python36-x64"
+      CONDA: "C:\\Miniconda36-x64"
       NOX_SESSION: "tests-3.6"
 
     - PYTHON: "C:\\Python37"
+      CONDA: "C:\\Miniconda37"
       NOX_SESSION: "tests-3.7"
 
     - PYTHON: "C:\\Python37-x64"
+      CONDA: "C:\\Miniconda37-x64"
       NOX_SESSION: "tests-3.7"
 
 install:
+  # Add conda command to path.
+  - "SET PATH=%CONDA%;%CONDA%\\Scripts;%PATH%"
+
   # Prepend newly installed Python to the PATH of this build (this cannot be
   # done from inside the powershell script as it would require to restart
   # the parent CMD process).

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,8 @@ environment:
     # See: http://www.appveyor.com/docs/installed-software#python
 
     - PYTHON: "C:\\Python35"
-      CONDA: "C:\\Miniconda35"
+      # 32-bit Python not available with miniconda.
+      CONDA: "C:\\Miniconda35-x64"
       NOX_SESSION: "tests-3.5"
 
     - PYTHON: "C:\\Python35-x64"
@@ -19,15 +20,16 @@ environment:
       NOX_SESSION: "tests-3.5"
 
     - PYTHON: "C:\\Python36"
-      CONDA: "C:\\Miniconda36"
-      NOX_SESSION: "tests-3.6"
-
-    - PYTHON: "C:\\Python36-x64"
+      # 32-bit Python not available with miniconda.
       CONDA: "C:\\Miniconda36-x64"
       NOX_SESSION: "tests-3.6"
 
+    - PYTHON: "C:\\Python36-x64"
+      NOX_SESSION: "tests-3.6"
+
     - PYTHON: "C:\\Python37"
-      CONDA: "C:\\Miniconda37"
+      # 32-bit Python not available with miniconda.
+      CONDA: "C:\\Miniconda37-x64"
       NOX_SESSION: "tests-3.7"
 
     - PYTHON: "C:\\Python37-x64"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,10 +19,12 @@ environment:
       NOX_SESSION: "tests-3.5"
 
     - PYTHON: "C:\\Python36"
-      CONDA: "C:\\Miniconda36"
+      # No 32-bit version of pip for Python 3.6 on conda-forge.
+      CONDA: "C:\\Miniconda36-x64"
       NOX_SESSION: "tests-3.6"
 
     - PYTHON: "C:\\Python36-x64"
+      CONDA: "C:\\Miniconda36-x64"
       NOX_SESSION: "tests-3.6"
 
     - PYTHON: "C:\\Python37"

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -19,7 +19,9 @@ import functools
 _REGISTRY = collections.OrderedDict()
 
 
-def session_decorator(func=None, python=None, py=None, reuse_venv=None, name=None):
+def session_decorator(
+    func=None, python=None, py=None, reuse_venv=None, name=None, venv_backend=None
+):
     """Designate the decorated function as a session."""
     # If `func` is provided, then this is the decorator call with the function
     # being sent as part of the Python syntax (`@nox.session`).
@@ -30,7 +32,12 @@ def session_decorator(func=None, python=None, py=None, reuse_venv=None, name=Non
     # This is what makes the syntax with and without parentheses both work.
     if func is None:
         return functools.partial(
-            session_decorator, python=python, py=py, reuse_venv=reuse_venv, name=name
+            session_decorator,
+            python=python,
+            py=py,
+            reuse_venv=reuse_venv,
+            name=name,
+            venv_backend=venv_backend,
         )
 
     if py is not None and python is not None:
@@ -44,6 +51,7 @@ def session_decorator(func=None, python=None, py=None, reuse_venv=None, name=Non
 
     func.python = python
     func.reuse_venv = reuse_venv
+    func.venv_backend = venv_backend
     _REGISTRY[name or func.__name__] = func
 
     return func

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -207,12 +207,11 @@ class Session:
         if self._runner.global_config.error_on_external_run:
             kwargs.setdefault("external", "error")
 
-        # If we aren't using a virtualenv allow all external programs.
-        if not isinstance(self.virtualenv, (CondaEnv, VirtualEnv)):
+        # Allow all external programs when running outside a sandbox.
+        if not self.virtualenv.is_sandboxed:
             kwargs["external"] = True
 
-        # Allow the global conda command from conda environments.
-        if isinstance(self.virtualenv, CondaEnv) and args[0] == "conda":
+        if args[0] in self.virtualenv.allowed_globals:
             kwargs["external"] = True
 
         # Run a shell command.
@@ -258,7 +257,6 @@ class Session:
             "conda",
             "install",
             "--yes",
-            "--use-index-cache",
             "--prefix",
             self.virtualenv.location,
             *args,

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -254,6 +254,7 @@ class Session:
             "conda",
             "install",
             "--yes",
+            "--use-index-cache",
             "--prefix",
             self.virtualenv.location,
             *args,

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -208,7 +208,11 @@ class Session:
             kwargs.setdefault("external", "error")
 
         # If we aren't using a virtualenv allow all external programs.
-        if not isinstance(self.virtualenv, VirtualEnv):
+        if not isinstance(self.virtualenv, (CondaEnv, VirtualEnv)):
+            kwargs["external"] = True
+
+        # Allow the global conda command from conda environments.
+        if isinstance(self.virtualenv, CondaEnv) and args[0] == "conda":
             kwargs["external"] = True
 
         # Run a shell command.

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -250,7 +250,16 @@ class Session:
         if "silent" not in kwargs:
             kwargs["silent"] = True
 
-        self._run("conda", "install", *args, external="error", **kwargs)
+        self._run(
+            "conda",
+            "install",
+            "--yes",
+            "--prefix",
+            self.virtualenv.location,
+            *args,
+            external="error",
+            **kwargs
+        )
 
     def install(self, *args, **kwargs):
         """Install invokes `pip`_ to install packages inside of the session's

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -23,7 +23,7 @@ import py
 
 import nox.command
 from nox.logger import logger
-from nox.virtualenv import ProcessEnv, VirtualEnv
+from nox.virtualenv import CondaEnv, ProcessEnv, VirtualEnv
 
 
 def _normalize_path(envdir, path):
@@ -214,6 +214,44 @@ class Session:
         # Run a shell command.
         return nox.command.run(args, env=env, path=self.bin, **kwargs)
 
+    def conda_install(self, *args, **kwargs):
+        """Install invokes `conda install`_ to install packages inside of the
+        session's environment.
+
+        To install packages directly::
+
+            session.conda_install('pandas')
+            session.conda_install('numpy', 'scipy')
+            session.conda_install('--channel=conda-forge', 'dask==2.1.0')
+
+        To install packages from a `requirements.txt` file::
+
+            session.conda_install('--file', 'requirements.txt')
+            session.conda_install('--file', 'requirements-dev.txt')
+
+        To install the current package without clobbering conda-installed
+        dependencies::
+
+            session.install('.', '--no-deps')
+            # Install in editable mode.
+            session.install('-e', '.', '--no-deps')
+
+        Additional keyword args are the same as for :meth:`run`.
+
+        .. _conda install:
+        """
+        if not isinstance(self.virtualenv, CondaEnv):
+            raise ValueError(
+                "A session without a conda environment can not install dependencies from conda."
+            )
+        if not args:
+            raise ValueError("At least one argument required to install().")
+
+        if "silent" not in kwargs:
+            kwargs["silent"] = True
+
+        self._run("conda", "install", *args, external="error", **kwargs)
+
     def install(self, *args, **kwargs):
         """Install invokes `pip`_ to install packages inside of the session's
         virtualenv.
@@ -239,7 +277,7 @@ class Session:
 
         .. _pip: https://pip.readthedocs.org
         """
-        if not isinstance(self.virtualenv, VirtualEnv):
+        if not isinstance(self.virtualenv, (CondaEnv, VirtualEnv)):
             raise ValueError(
                 "A session without a virtualenv can not install dependencies."
             )
@@ -311,9 +349,22 @@ class SessionRunner:
         reuse_existing = (
             self.func.reuse_venv or self.global_config.reuse_existing_virtualenvs
         )
-        self.venv = VirtualEnv(
-            path, interpreter=self.func.python, reuse_existing=reuse_existing
-        )
+
+        if not self.func.venv_backend or self.func.venv_backend == "virtualenv":
+            self.venv = VirtualEnv(
+                path, interpreter=self.func.python, reuse_existing=reuse_existing
+            )
+        elif self.func.venv_backend == "conda":
+            self.venv = CondaEnv(
+                path, interpreter=self.func.python, reuse_existing=reuse_existing
+            )
+        else:
+            raise ValueError(
+                "Expected venv_backend one of ('virtualenv', 'conda'), but got '{}'.".format(
+                    self.func.venv_backend
+                )
+            )
+
         self.venv.create()
 
     def execute(self):

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -109,7 +109,6 @@ class CondaEnv(ProcessEnv):
         self.location_name = location
         self.location = os.path.abspath(location)
         self.interpreter = interpreter
-        self._resolved = None
         self.reuse_existing = reuse_existing
         super(CondaEnv, self).__init__()
 
@@ -139,7 +138,7 @@ class CondaEnv(ProcessEnv):
             )
             return False
 
-        cmd = ["conda", "create", "--prefix", self.location]
+        cmd = ["conda", "create", "--yes", "--prefix", self.location]
 
         if self.interpreter:
             cmd.append("python={}".format(self.interpreter))

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -40,6 +40,12 @@ class InterpreterNotFound(OSError):
 class ProcessEnv:
     """A environment with a 'bin' directory and a set of 'env' vars."""
 
+    # Does this environment provide any process isolation?
+    is_sandboxed = False
+
+    # Special programs that aren't included in the environment.
+    allowed_globals = ()
+
     def __init__(self, bin=None, env=None):
         self._bin = bin
         self.env = os.environ.copy()
@@ -116,6 +122,9 @@ class CondaEnv(ProcessEnv):
             should be reused if it already exists at ``location``.
     """
 
+    is_sandboxed = True
+    allowed_globals = ("conda",)
+
     def __init__(self, location, interpreter=None, reuse_existing=False):
         self.location_name = location
         self.location = os.path.abspath(location)
@@ -145,7 +154,6 @@ class CondaEnv(ProcessEnv):
             "conda",
             "create",
             "--yes",
-            "--use-index-cache",
             "--prefix",
             self.location,
             # Ensure the pip package is installed.
@@ -185,6 +193,8 @@ class VirtualEnv(ProcessEnv):
         reuse_existing (Optional[bool]): Flag indicating if the virtual environment
             should be reused if it already exists at ``location``.
     """
+
+    is_sandboxed = True
 
     def __init__(self, location, interpreter=None, reuse_existing=False):
         self.location_name = location

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -148,6 +148,8 @@ class CondaEnv(ProcessEnv):
             "--use-index-cache",
             "--prefix",
             self.location,
+            # Ensure the pip package is installed.
+            "pip",
         ]
 
         if self.interpreter:

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -129,7 +129,7 @@ class CondaEnv(ProcessEnv):
     def bin(self):
         """Returns the location of the conda env's bin folder."""
         if _SYSTEM == "Windows":
-            return self.location
+            return os.path.join(self.location, "Scripts")
         else:
             return os.path.join(self.location, "bin")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,6 +32,16 @@ def tests(session):
     session.notify("cover")
 
 
+@nox.session(python=["3.5", "3.6", "3.7"], venv_backend="conda")
+def conda_tests(session):
+    """Run test suite with pytest."""
+    session.conda_install("--file", "requirements-conda-test.txt")
+    session.install("contexter", "--no-deps")
+    session.install("-e", ".", "--no-deps")
+    tests = session.posargs or ["tests/"]
+    session.run("pytest", *tests)
+
+
 @nox.session
 def cover(session):
     """Coverage analysis."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,16 +32,6 @@ def tests(session):
     session.notify("cover")
 
 
-@nox.session(python=["3.5", "3.6", "3.7"], venv_backend="conda")
-def conda_tests(session):
-    """Run test suite with pytest."""
-    session.conda_install("--file", "requirements-conda-test.txt")
-    session.install("contexter", "--no-deps")
-    session.install("-e", ".", "--no-deps")
-    tests = session.posargs or ["tests/"]
-    session.run("pytest", *tests)
-
-
 @nox.session
 def cover(session):
     """Coverage analysis."""

--- a/requirements-conda-test.txt
+++ b/requirements-conda-test.txt
@@ -1,0 +1,6 @@
+colorlog >=2.6.1,<4.0.0
+py >=1.4.0,<2.0.0
+virtualenv >=14.0.0
+jinja2
+tox
+pytest

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -205,8 +205,10 @@ class TestSession:
         # condaenv sessions should always allow conda.
         session, runner = self.make_session_and_runner()
         runner.venv = mock.create_autospec(nox.virtualenv.CondaEnv)
+        runner.venv.allowed_globals = ("conda",)
         runner.venv.env = {}
         runner.venv.bin = "/path/to/env/bin"
+        runner.venv.create.return_value = True
 
         with mock.patch("nox.command.run", autospec=True) as run:
             session.run("conda", "--version")
@@ -272,7 +274,6 @@ class TestSession:
                 "conda",
                 "install",
                 "--yes",
-                "--use-index-cache",
                 "--prefix",
                 "/path/to/conda/env",
                 "requests",
@@ -304,7 +305,6 @@ class TestSession:
                 "conda",
                 "install",
                 "--yes",
-                "--use-index-cache",
                 "--prefix",
                 "/path/to/conda/env",
                 "requests",

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -318,6 +318,7 @@ class TestSessionRunner:
     def make_runner(self):
         func = mock.Mock()
         func.python = None
+        func.venv_backend = None
         func.reuse_venv = False
         runner = nox.sessions.SessionRunner(
             name="test",

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -75,9 +75,9 @@ def test_condaenv_create(make_conda):
     venv.create()
 
     if IS_WINDOWS:
-        assert dir_.join("python.exe").check()
-        assert dir_.join("pip.exe").check()
-        assert dir_.join("Lib").check()
+        assert dir_.join("bin", "python.exe").check()
+        assert dir_.join("bin", "pip.exe").check()
+        assert dir_.join("Library").check()
     else:
         assert dir_.join("bin", "python").check()
         assert dir_.join("bin", "pip").check()

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+import shutil
 import sys
 from unittest import mock
 
@@ -23,6 +24,7 @@ import nox.virtualenv
 
 
 IS_WINDOWS = nox.virtualenv._SYSTEM == "Windows"
+HAS_CONDA = shutil.which("conda") is not None
 
 
 @pytest.fixture
@@ -67,6 +69,7 @@ def test_condaenv_constructor_explicit(make_conda):
     assert venv.reuse_existing is True
 
 
+@pytest.mark.skipif(not HAS_CONDA, reason="Missing conda command.")
 def test_condaenv_create(make_conda):
     venv, dir_ = make_conda()
     venv.create()
@@ -95,6 +98,7 @@ def test_condaenv_create(make_conda):
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="Not testing multiple interpreters on Windows.")
+@pytest.mark.skipif(not HAS_CONDA, reason="Missing conda command.")
 def test_condaenv_create_interpreter(make_conda):
     venv, dir_ = make_conda(interpreter="3.7")
     venv.create()
@@ -103,8 +107,8 @@ def test_condaenv_create_interpreter(make_conda):
 
 
 @mock.patch("nox.virtualenv._SYSTEM", new="Windows")
-def test_condaenv_bin_windows(make_one):
-    venv, dir_ = make_one()
+def test_condaenv_bin_windows(make_conda):
+    venv, dir_ = make_conda()
     assert dir_.strpath == venv.bin
 
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -76,7 +76,8 @@ def test_condaenv_create(make_conda):
 
     if IS_WINDOWS:
         assert dir_.join("python.exe").check()
-        assert dir_.join("bin", "pip.exe").check()
+        assert dir_.join("Scripts", "pip.exe").check()
+        assert dir_.join("Scripts", "python.exe").check()
         assert dir_.join("Library").check()
     else:
         assert dir_.join("bin", "python").check()

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -75,7 +75,7 @@ def test_condaenv_create(make_conda):
     venv.create()
 
     if IS_WINDOWS:
-        assert dir_.join("bin", "python.exe").check()
+        assert dir_.join("python.exe").check()
         assert dir_.join("bin", "pip.exe").check()
         assert dir_.join("Library").check()
     else:

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -109,7 +109,7 @@ def test_condaenv_create_interpreter(make_conda):
 @mock.patch("nox.virtualenv._SYSTEM", new="Windows")
 def test_condaenv_bin_windows(make_conda):
     venv, dir_ = make_conda()
-    assert dir_.strpath == venv.bin
+    assert dir_.join("Scripts").strpath == venv.bin
 
 
 def test_constructor_defaults(make_one):

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -77,7 +77,6 @@ def test_condaenv_create(make_conda):
     if IS_WINDOWS:
         assert dir_.join("python.exe").check()
         assert dir_.join("Scripts", "pip.exe").check()
-        assert dir_.join("Scripts", "python.exe").check()
         assert dir_.join("Library").check()
     else:
         assert dir_.join("bin", "python").check()


### PR DESCRIPTION
Also adds a `session.conda_install()` function to install packages with
conda, instead of pip.

Towards #199

Closes #183 