### PR TITLE
Document how to session.run builtins on Windows

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -165,6 +165,11 @@ class Session:
                 'pytest', '-k', 'not slow',
                 success_codes=[0, 5])
 
+        On Windows, builtin commands like ``del`` cannot be directly invoked,
+        but you can use ``cmd /c`` to invoke them::
+
+            session.run('cmd', '/c', 'del', 'docs/modules.rst')
+
         :param env: A dictionary of environment variables to expose to the
             command. By default, all environment variables are passed.
         :type env: dict or None


### PR DESCRIPTION
In order to fix #220 

I tried to succinctly implement option (2) from https://github.com/theacodes/nox/issues/220#issuecomment-513123726:

```
2. Make it clearer in docs what kinds of commands can and cannot be run, and point users to python commands like os.remove to help them along (ideally with example(s)). The burden to deal with asymmetries is with the user, but we help them along. Thanks @tswast for the pointers to those!
```