### PR TITLE
Resolve to interpreter 'python' in PATH if '--version' fits

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -104,13 +104,13 @@ def locate_using_path_and_version(version):
     if not version:
         return None
 
+    script = "import platform; print(platform.python_version())"
     path_python = py.path.local.sysfind("python")
     if path_python:
         try:
-            version_pattern = "^Python {}".format(version)
-            version_string = path_python.sysexec("--version").strip()
-            match = re.match(version_pattern, version_string)
-            if match:
+            prefix = "{}.".format(version)
+            version_string = path_python.sysexec("-c", script).strip()
+            if version_string.startswith(prefix):
                 return path_python
         except py.process.cmdexec.Error:
             return None

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -111,7 +111,7 @@ def locate_using_path_and_version(version):
             prefix = "{}.".format(version)
             version_string = path_python.sysexec("-c", script).strip()
             if version_string.startswith(prefix):
-                return path_python
+                return str(path_python)
         except py.process.cmdexec.Error:
             return None
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -344,7 +344,7 @@ def test__resolved_interpreter_windows_path_and_version(
     )
 
     # Okay, now run the test.
-    assert str(venv._resolved_interpreter) == correct_path
+    assert venv._resolved_interpreter == correct_path
 
 
 @pytest.mark.parametrize("input_", ["2.7", "python3.7", "goofy"])


### PR DESCRIPTION
To fix #219 

TL;DR: Trying to implement the suggestion in https://github.com/theacodes/nox/issues/219#issuecomment-512933886, this PR adds a final check at the end of the property ``nox.virtualenv._resolved_interpreter`` which looks for an interpreter called "python" in the ``PATH``, checks whether its ``--version`` fits the required version, and returns it as the resolved interpreter if it matches.

### Rationale
As described in #219, sessions specifying the interpreter version (e.g. ``@nox.session(python='3.7')``) don't find the existing matching python 3.7 if it is called "python" or "python.exe" and no python launcher ("py.exe") is available.

The same sessions work when not specifying python='3.7', even if the used interpreter is actually python 3.7. If this happens, it makes it harder for collaborators on Unix/Windows to work on cross-platform libraries together (like ``nox`` or [my current pet project](/schuderer/mllaunchpad)) without temporarily adapting the noxfile to their own system (or their system to the noxfile).

While the mechanisms applied in ``nox.virtualenvs`` do follow the Python guidelines, in practice, Anaconda installations on Windows, which are quite popular in my scientific/data-wrangling field, provide neither versioned interpreters (like 'python2', 'python27', 'python3', 'python37') nor a python launcher.

For Anaconda-specific projects, the recent addition of conda environment support to ``nox`` is certainly very interesting. However, I am arguing from the perspective of cross-platform library development and would like to be able to provide a noxfile to my project which works on Unix and Windows, be it with Anaconda or with "proper" Python installations.

One could argue that this is not ``nox``s problem and should be fixed in Anaconda (and one would be right), but it is a pretty small addition and would in one step increase the reach for nox to everyone using Anaconda on Windows (which are quite a few people). And it would make it easier for me (and ``nox`` ;)) to find Windows contributors also.

### Implementation
Added the check (with an extra module-level function for cleanliness), and some parametrised tests. I also fixed two incorrect return value mocks of ``py.path.local.sysfind`` (which returns ``None`` on not found, not ``False`` like in the mock return value), which my code initially tripped over because it checked for ``None``.

As the body of ``_resolved_interpreter`` is essentially a string of if-else conditionals, creating good tests was a bit of a challenge. I hope they're not too ugly. :)