### PR TITLE
add shell autocomplete

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -313,3 +313,40 @@ This will create a ``noxfile.py`` based on the environments in your ``tox.ini``.
 
 .. _Generative environments: http://tox.readthedocs.io/en/latest/config.html#generating-environments-conditional-settings
 .. _substitutions: http://tox.readthedocs.io/en/latest/config.html#substitutions
+
+
+Shell Completion
+----------------
+Add the appropriate command to your shell's config file
+so that it is run on startup. You will likely have to restart
+or re-login for the autocompletion to start working.
+
+bash
+
+.. code-block:: console
+
+    eval "$(register-python-argcomplete nox)"
+
+zsh
+
+.. code-block:: console
+
+    # To activate completions for zsh you need to have
+    # bashcompinit enabled in zsh:
+    autoload -U bashcompinit
+    bashcompinit
+
+    # Afterwards you can enable completion for nox:
+    eval "$(register-python-argcomplete nox)"
+
+tcsh
+
+.. code-block:: console
+
+    eval `register-python-argcomplete --shell tcsh nox`
+
+fish
+
+.. code-block:: console
+
+    register-python-argcomplete --shell fish nox | .

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -17,10 +17,11 @@ can be specified from the command line and the noxfile, easily used in tests,
 and surfaced in documentation."""
 
 
-import argcomplete
 import argparse
 import collections
 import functools
+
+import argcomplete  # type: ignore
 
 Namespace = argparse.Namespace
 ArgumentError = argparse.ArgumentError

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -17,10 +17,10 @@ can be specified from the command line and the noxfile, easily used in tests,
 and surfaced in documentation."""
 
 
+import argcomplete
 import argparse
 import collections
 import functools
-
 
 Namespace = argparse.Namespace
 ArgumentError = argparse.ArgumentError
@@ -68,6 +68,7 @@ class Option:
         finalizer_func=None,
         default=None,
         hidden=False,
+        completer=None,
         **kwargs
     ):
         self.name = name
@@ -78,6 +79,7 @@ class Option:
         self.merge_func = merge_func
         self.finalizer_func = finalizer_func
         self.hidden = hidden
+        self.completer = completer
         self.kwargs = kwargs
         self._default = default
 
@@ -187,9 +189,11 @@ class OptionSet:
         self.groups[name] = (args, kwargs)
 
     def _add_to_parser(self, parser, option):
-        parser.add_argument(
+        argument = parser.add_argument(
             *option.flags, help=option.help, default=option.default, **option.kwargs
         )
+        if option.completer:
+            argument.completer = option.completer
 
     def parser(self):
         """Returns an ``ArgumentParser`` for this option set.
@@ -233,6 +237,7 @@ class OptionSet:
 
     def parse_args(self):
         parser = self.parser()
+        argcomplete.autocomplete(parser)
         args = parser.parse_args()
 
         try:

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -17,8 +17,8 @@ import functools
 import os
 import sys
 
-from nox.tasks import load_nox_module, discover_manifest, filter_manifest
 from nox import _option_set
+from nox.tasks import discover_manifest, filter_manifest, load_nox_module
 
 """All of nox's configuration options."""
 

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -98,30 +98,8 @@ def _color_finalizer(value, args):
     return sys.stdin.isatty()
 
 
-def _session_completer(*args, **kwargs):
-    global_config = argparse.Namespace(
-        color=False,
-        envdir=".nox",  # TODO determine this dynamically
-        error_on_external_run=None,
-        error_on_missing_interpreters=None,
-        forcecolor=False,
-        help=None,
-        install_only=None,
-        keywords=None,
-        list_sessions=True,
-        no_error_on_external_run=None,
-        no_error_on_missing_interpreters=None,
-        no_reuse_existing_virtualenvs=None,
-        no_stop_on_first_error=None,
-        nocolor=False,
-        non_interactive=None,
-        noxfile="noxfile.py",  # # TODO determine this dynamically
-        reuse_existing_virtualenvs=None,
-        sessions=None,
-        stop_on_first_error=None,
-        version=None,
-    )
-
+def _session_completer(prefix, parsed_args, **kwargs):
+    global_config = parsed_args
     module = load_nox_module(global_config)
     manifest = discover_manifest(module, global_config)
     filtered_manifest = filter_manifest(manifest, global_config)

--- a/setup.py
+++ b/setup.py
@@ -49,6 +49,7 @@ setup(
     packages=["nox"],
     include_package_data=True,
     install_requires=[
+        "argcomplete>=1.9.4, <2.0",
         "colorlog>=2.6.1,<4.0.0",
         "py>=1.4.0,<2.0.0",
         "virtualenv>=14.0.0",

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -12,9 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import sys
+from unittest import mock
+
 import pytest
 
 from nox import _option_set
+from nox import _options
 
 
 # The vast majority of _option_set is tested by test_main, but the test helper
@@ -45,3 +49,14 @@ class TestOptionSet:
 
         with pytest.raises(KeyError):
             optionset.namespace(non_existant_option="meep")
+
+    def test_session_completer(self):
+        with mock.patch("sys.argv", [sys.executable]):
+            parsed_args = _options.options.parse_args()
+            all_nox_sessions = _options._session_completer(
+                prefix=None, parsed_args=parsed_args
+            )
+            # if noxfile.py changes, this will have to change as well since these are
+            # some of the actual sessions found in noxfile.py
+            some_expected_sessions = ["cover", "blacken", "lint", "docs"]
+            assert len(set(some_expected_sessions) - set(all_nox_sessions)) == 0


### PR DESCRIPTION
To try this out in bash run the following. Other shells also have limited support. See instructions in the docs in this PR.
```
pip install .  # from nox directory since a new dependency is required
eval "$(register-python-argcomplete nox)"
nox <tab>
nox --<tab>
nox -s <tab>
```

A sample of the autocompletions for all items that start with a `--`:
![image](https://user-images.githubusercontent.com/5715368/62430777-d20f0600-b6d5-11e9-8e81-0c54e2a250ad.png)

The  `_session_completer` function provides a list of sessions when hitting tab in `nox -s <tab>`. argcomplete provides `parsed_args` to this function, which is the Namespace argparse would have returned if the program were actually run. This corresponds almost directly to nox's global_config, and it works out of the box :smile: .

Note that this adds a new dependency to nox in setup.py, `argcomplete`.

fixes https://github.com/theacodes/nox/issues/227

cc @theacodes 


