### PR TITLE
immediately exit if unknown arguments are passed

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
 # Ignore black styles.
-ignore = E501, W503
+ignore = E501, W503, E203
 # Imports
 import-order-style = google
 application-import-names = nox,tests

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -20,7 +20,7 @@ and surfaced in documentation."""
 import argparse
 import collections
 import functools
-import sys
+
 
 Namespace = argparse.Namespace
 ArgumentError = argparse.ArgumentError
@@ -68,7 +68,7 @@ class Option:
         finalizer_func=None,
         default=None,
         hidden=False,
-        **kwargs,
+        **kwargs
     ):
         self.name = name
         self.flags = flags
@@ -143,7 +143,7 @@ def make_flag_pair(name, enable_flags, disable_flags, **kwargs):
         *enable_flags,
         noxfile=True,
         merge_func=functools.partial(flag_pair_merge_func, name, disable_name),
-        **kwargs,
+        **kwargs
     )
 
     kwargs["help"] = "Disables {} if it is enabled in the Noxfile.".format(
@@ -233,22 +233,8 @@ class OptionSet:
 
     def parse_args(self):
         parser = self.parser()
-        all_args = sys.argv[1:]
-        if "--" in all_args:
-            split_index = all_args.index("--")
-            nox_args = all_args[0:split_index]
-            posargs = all_args[split_index + 1 :]
-        else:
-            nox_args = all_args
-            posargs = []
+        args = parser.parse_args()
 
-        args = parser.parse_args(nox_args)
-        if args.posargs:
-            # posargs should not be present since we explicitly only parsed
-            # values before the '--'
-            parser.error(f"Unrecognized argument(s): '{' '.join(args.posargs)}'")
-
-        args.posargs = posargs
         try:
             self._finalize_args(args)
         except ArgumentError as err:

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -20,7 +20,7 @@ and surfaced in documentation."""
 import argparse
 import collections
 import functools
-
+import sys
 
 Namespace = argparse.Namespace
 ArgumentError = argparse.ArgumentError
@@ -68,7 +68,7 @@ class Option:
         finalizer_func=None,
         default=None,
         hidden=False,
-        **kwargs
+        **kwargs,
     ):
         self.name = name
         self.flags = flags
@@ -143,7 +143,7 @@ def make_flag_pair(name, enable_flags, disable_flags, **kwargs):
         *enable_flags,
         noxfile=True,
         merge_func=functools.partial(flag_pair_merge_func, name, disable_name),
-        **kwargs
+        **kwargs,
     )
 
     kwargs["help"] = "Disables {} if it is enabled in the Noxfile.".format(
@@ -233,8 +233,22 @@ class OptionSet:
 
     def parse_args(self):
         parser = self.parser()
-        args = parser.parse_args()
+        all_args = sys.argv[1:]
+        if "--" in all_args:
+            split_index = all_args.index("--")
+            nox_args = all_args[0:split_index]
+            posargs = all_args[split_index + 1 :]
+        else:
+            nox_args = all_args
+            posargs = []
 
+        args = parser.parse_args(nox_args)
+        if args.posargs:
+            # posargs should not be present since we explicitly only parsed
+            # values before the '--'
+            parser.error(f"Unrecognized argument(s): '{' '.join(args.posargs)}'")
+
+        args.posargs = posargs
         try:
             self._finalize_args(args)
         except ArgumentError as err:

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -118,9 +118,7 @@ def _posargs_finalizer(value, args):
             None, "Unknown argument(s) '{}'.".format(" ".join(unexpected_posargs))
         )
 
-    # fmt: off
-    return posargs[dash_index + 1:]
-    # fmt: on
+    return posargs[dash_index + 1 :]
 
 
 options.add_options(

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -97,13 +97,6 @@ def _color_finalizer(value, args):
     return sys.stdin.isatty()
 
 
-def _posargs_finalizer(value, unused_args):
-    """Removes any leading "--"s in the posargs array."""
-    if value and value[0] == "--":
-        value.pop(0)
-    return value
-
-
 options.add_options(
     _option_set.Option(
         "help",
@@ -156,7 +149,6 @@ options.add_options(
         group="primary",
         nargs=argparse.REMAINDER,
         help="Arguments following ``--`` that are passed through to the session(s).",
-        finalizer_func=_posargs_finalizer,
     ),
     *_option_set.make_flag_pair(
         "reuse_existing_virtualenvs",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -166,22 +166,27 @@ def test_main_session_from_nox_env_var(monkeypatch, env, sessions):
             assert session in config.sessions
 
 
-def test_main_positional_args(monkeypatch):
+def test_main_positional_args(capsys, monkeypatch):
+    fake_exit = mock.Mock(side_effect=ValueError("asdf!"))
+
     monkeypatch.setattr(sys, "argv", [sys.executable, "1", "2", "3"])
-
-    with pytest.raises(
-        AttributeError, match="object has no attribute 'color'"
-    ), mock.patch.object(sys, "exit") as _exit:
+    with mock.patch.object(sys, "exit", fake_exit), pytest.raises(
+        ValueError, match="asdf!"
+    ):
         nox.__main__.main()
-        _exit.assert_called_once_with(1)
+    _, stderr = capsys.readouterr()
+    assert "Unknown argument(s) '1 2 3'" in stderr
+    fake_exit.assert_called_once_with(2)
 
+    fake_exit.reset_mock()
     monkeypatch.setattr(sys, "argv", [sys.executable, "1", "2", "3", "--"])
-
-    with pytest.raises(
-        AttributeError, match="object has no attribute 'color'"
-    ), mock.patch.object(sys, "exit") as _exit:
+    with mock.patch.object(sys, "exit", fake_exit), pytest.raises(
+        ValueError, match="asdf!"
+    ):
         nox.__main__.main()
-        _exit.assert_called_once_with(1)
+    _, stderr = capsys.readouterr()
+    assert "Unknown argument(s) '1 2 3'" in stderr
+    fake_exit.assert_called_once_with(2)
 
 
 def test_main_positional_with_double_hyphen(monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import argparse
 import os
 import sys
 from unittest import mock

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import os
 import sys
 from unittest import mock
@@ -168,18 +169,10 @@ def test_main_session_from_nox_env_var(monkeypatch, env, sessions):
 
 def test_main_positional_args(monkeypatch):
     monkeypatch.setattr(sys, "argv", [sys.executable, "1", "2", "3"])
-    with mock.patch("nox.workflow.execute") as execute:
-        execute.return_value = 0
 
+    with pytest.raises(argparse.ArgumentError, match="1 2 3"):
         # Call the main function.
-        with mock.patch.object(sys, "exit") as exit:
-            nox.__main__.main()
-            exit.assert_called_once_with(0)
-        assert execute.called
-
-        # Verify that the positional args are listed in the config.
-        config = execute.call_args[1]["global_config"]
-        assert config.posargs == ["1", "2", "3"]
+        nox.__main__.main()
 
 
 def test_main_positional_with_double_hyphen(monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -170,9 +170,19 @@ def test_main_session_from_nox_env_var(monkeypatch, env, sessions):
 def test_main_positional_args(monkeypatch):
     monkeypatch.setattr(sys, "argv", [sys.executable, "1", "2", "3"])
 
-    with pytest.raises(argparse.ArgumentError, match="1 2 3"):
-        # Call the main function.
+    with pytest.raises(
+        AttributeError, match="object has no attribute 'color'"
+    ), mock.patch.object(sys, "exit") as _exit:
         nox.__main__.main()
+        _exit.assert_called_once_with(1)
+
+    monkeypatch.setattr(sys, "argv", [sys.executable, "1", "2", "3", "--"])
+
+    with pytest.raises(
+        AttributeError, match="object has no attribute 'color'"
+    ), mock.patch.object(sys, "exit") as _exit:
+        nox.__main__.main()
+        _exit.assert_called_once_with(1)
 
 
 def test_main_positional_with_double_hyphen(monkeypatch):


### PR DESCRIPTION
This PR adds changes to raise an error if an unknown argument is passed.

## Test plan

### before (all tests would run):
```
nox lint 
> nox 
nox > Running session tests-3.5
nox > Session tests-3.5 skipped: Python interpreter 3.5 not found.
nox > Running session tests-3.6
...
```
### after (error is raised):
```
>> nox lint
usage: nox [-h] [--version] [-l] [-s [SESSIONS [SESSIONS ...]]] [-k KEYWORDS]
           [-r] [--no-reuse-existing-virtualenvs] [-f NOXFILE]
           [--envdir ENVDIR] [-x] [--no-stop-on-first-error]
           [--error-on-missing-interpreters]
           [--no-error-on-missing-interpreters] [--error-on-external-run]
           [--no-error-on-external-run] [--install-only] [--report REPORT]
           [--non-interactive] [--nocolor] [--forcecolor]
           ...
nox: error: Unrecognized argument(s): 'lint'

>> nox -s lint
nox > Running session lint
nox > Creating virtualenv using python3.7 in .nox/lint
...
```

fixes https://github.com/theacodes/nox/issues/226
cc @theacodes 