### PR TITLE
add mypy to lint

### DIFF
--- a/nox/command.py
+++ b/nox/command.py
@@ -15,7 +15,7 @@
 import os
 import sys
 
-import py
+import py  # type: ignore
 
 from nox.logger import logger
 from nox.popen import popen

--- a/nox/logger.py
+++ b/nox/logger.py
@@ -14,12 +14,12 @@
 
 import logging
 
-from colorlog import ColoredFormatter
+from colorlog import ColoredFormatter  # type: ignore
 
 SUCCESS = 25
 
 
-class LoggerWithSuccess(logging.getLoggerClass()):
+class LoggerWithSuccess(logging.getLoggerClass()):  # type: ignore
     def __init__(self, name, level=logging.NOTSET):
         super(LoggerWithSuccess, self).__init__(name, level)
         logging.addLevelName(SUCCESS, "SUCCESS")

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -285,4 +285,4 @@ def _null_session_func(session):
     session.skip("This session had no parameters available.")
 
 
-_null_session_func.python = False
+_null_session_func.python = False  # type: ignore

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -16,7 +16,7 @@ import collections
 import copy
 import functools
 
-_REGISTRY = collections.OrderedDict()
+_REGISTRY = collections.OrderedDict()  # type: ignore
 
 
 def session_decorator(

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -19,7 +19,7 @@ import re
 import sys
 import unicodedata
 
-import py
+import py  # type: ignore
 
 import nox.command
 from nox.logger import logger

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -17,7 +17,7 @@ import io
 import json
 import os
 
-from colorlog.escape_codes import parse_colors
+from colorlog.escape_codes import parse_colors  # type: ignore
 
 import nox
 from nox import _options

--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -19,10 +19,10 @@ import io
 import pkgutil
 
 import jinja2
-import tox.config
+import tox.config  # type: ignore
 
 _TEMPLATE = jinja2.Template(
-    pkgutil.get_data(__name__, "tox_to_nox.jinja2").decode("utf-8"),
+    pkgutil.get_data(__name__, "tox_to_nox.jinja2").decode("utf-8"),  # type: ignore
     extensions=["jinja2.ext.do"],
 )
 

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -18,7 +18,7 @@ import re
 import shutil
 import sys
 
-import py
+import py  # type: ignore
 
 import nox.command
 from nox.logger import logger
@@ -123,7 +123,7 @@ class CondaEnv(ProcessEnv):
     """
 
     is_sandboxed = True
-    allowed_globals = ("conda",)
+    allowed_globals = ("conda",)  # type: ignore
 
     def __init__(self, location, interpreter=None, reuse_existing=False):
         self.location_name = location

--- a/noxfile.py
+++ b/noxfile.py
@@ -63,8 +63,8 @@ def blacken(session):
 
 @nox.session(python="3.7")
 def lint(session):
-    """Lint using flake8."""
-    session.install("flake8", "flake8-import-order", "black")
+    session.install("flake8", "flake8-import-order", "black", "mypy")
+    session.run("mypy", "nox")
     session.run("black", "--check", "nox", "tests", "noxfile.py", "setup.py")
     session.run("flake8", "nox", "tests")
 


### PR DESCRIPTION
Type checking has lots of benefits for a codebase. I'm not sure if the lack of type checks in nox is intentional, but since nox supports Python 3.5+ it can use types. I went ahead and added mypy to the lint session and ignored all the existing mypy errors so it all passes. 

Future PRs can add more types to existing functions and gradually remove the ignored type checks. Of course if you aren't interested in types, feel free to decline this PR but it was something I would have benefited from as a newcomer trying to navigate the codebase, so I thought I'd put up a PR 😄 .