### PR TITLE
add venv as an option for venv_backend

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -384,7 +384,7 @@ class SessionRunner:
             )
         else:
             raise ValueError(
-                "Expected venv_backend one of ('virtualenv', 'conda'), but got '{}'.".format(
+                "Expected venv_backend one of ('virtualenv', 'conda', 'venv'), but got '{}'.".format(
                     self.func.venv_backend
                 )
             )

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -375,6 +375,13 @@ class SessionRunner:
             self.venv = CondaEnv(
                 path, interpreter=self.func.python, reuse_existing=reuse_existing
             )
+        elif self.func.venv_backend == "venv":
+            self.venv = VirtualEnv(
+                path,
+                interpreter=self.func.python,
+                reuse_existing=reuse_existing,
+                venv=True,
+            )
         else:
             raise ValueError(
                 "Expected venv_backend one of ('virtualenv', 'conda'), but got '{}'.".format(

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -285,10 +285,12 @@ class VirtualEnv(ProcessEnv):
             )
             return False
 
-        cmd = [sys.executable, "-m", self.venv_or_virtualenv, self.location]
-
-        if self.interpreter and self.venv_or_virtualenv == "virtualenv":
-            cmd.extend(["-p", self._resolved_interpreter])
+        if self.venv_or_virtualenv == "virtualenv":
+            cmd = [sys.executable, "-m", "virtualenv", self.location]
+            if self.interpreter:
+                cmd.extend(["-p", self._resolved_interpreter])
+        else:
+            cmd = [self._resolved_interpreter, "-m", "venv", self.location]
 
         logger.info(
             "Creating virtual environment ({}) using {} in {}".format(

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -514,6 +514,7 @@ class TestSessionRunner:
                 "virtualenv",
                 nox.virtualenv.VirtualEnv,
             ),
+            ("nox.virtualenv.VirtualEnv.create", 'venv', nox.virtualenv.VirtualEnv),
             ("nox.virtualenv.CondaEnv.create", "conda", nox.virtualenv.CondaEnv),
         ],
     )

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -514,7 +514,7 @@ class TestSessionRunner:
                 "virtualenv",
                 nox.virtualenv.VirtualEnv,
             ),
-            ("nox.virtualenv.VirtualEnv.create", 'venv', nox.virtualenv.VirtualEnv),
+            ("nox.virtualenv.VirtualEnv.create", "venv", nox.virtualenv.VirtualEnv),
             ("nox.virtualenv.CondaEnv.create", "conda", nox.virtualenv.CondaEnv),
         ],
     )

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -38,6 +38,16 @@ def make_one(tmpdir):
 
 
 @pytest.fixture
+def make_venv(tmpdir):
+    def factory(*args, **kwargs):
+        location = tmpdir.join("venv")
+        venv = nox.virtualenv.VirtualEnv(location.strpath, *args, venv=True, **kwargs)
+        return (venv, location)
+
+    return factory
+
+
+@pytest.fixture
 def make_conda(tmpdir):
     def factory(*args, **kwargs):
         location = tmpdir.join("condaenv")
@@ -67,6 +77,14 @@ def test_condaenv_constructor_explicit(make_conda):
     assert venv.location
     assert venv.interpreter == "3.5"
     assert venv.reuse_existing is True
+
+
+def test_venv_constructor_defaults(make_venv):
+    venv, _ = make_venv()
+    assert venv.location
+    assert venv.interpreter is None
+    assert venv.reuse_existing is False
+    assert venv.venv_or_virtualenv == "venv"
 
 
 @pytest.mark.skipif(not HAS_CONDA, reason="Missing conda command.")
@@ -117,6 +135,7 @@ def test_constructor_defaults(make_one):
     assert venv.location
     assert venv.interpreter is None
     assert venv.reuse_existing is False
+    assert venv.venv_or_virtualenv == "virtualenv"
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="Not testing multiple interpreters on Windows.")

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -38,16 +38,6 @@ def make_one(tmpdir):
 
 
 @pytest.fixture
-def make_venv(tmpdir):
-    def factory(*args, **kwargs):
-        location = tmpdir.join("venv")
-        venv = nox.virtualenv.VirtualEnv(location.strpath, *args, venv=True, **kwargs)
-        return (venv, location)
-
-    return factory
-
-
-@pytest.fixture
 def make_conda(tmpdir):
     def factory(*args, **kwargs):
         location = tmpdir.join("condaenv")
@@ -77,14 +67,6 @@ def test_condaenv_constructor_explicit(make_conda):
     assert venv.location
     assert venv.interpreter == "3.5"
     assert venv.reuse_existing is True
-
-
-def test_venv_constructor_defaults(make_venv):
-    venv, _ = make_venv()
-    assert venv.location
-    assert venv.interpreter is None
-    assert venv.reuse_existing is False
-    assert venv.venv_or_virtualenv == "venv"
 
 
 @pytest.mark.skipif(not HAS_CONDA, reason="Missing conda command.")
@@ -230,6 +212,11 @@ def test_create(make_one):
     venv.reuse_existing = True
     venv.create()
     assert dir_.join("test.txt").check()
+
+
+def test_create_venv_backend(make_one):
+    venv, dir_ = make_one(venv=True)
+    venv.create()
 
 
 @pytest.mark.skipif(IS_WINDOWS, reason="Not testing multiple interpreters on Windows.")


### PR DESCRIPTION
### Summary

This PR adds support for a different backend, `venv`. It adds a keyword argument to the `VirtualEnv` class, which defaults to `False` and is only true when the nox session has `venv_backend=True`.

It also updates the resolution of the Python path, since using `venv` alone does not fix issues when creating a venv from within a virtual environment.

The path resolution is modified to determine if a virtual environment is being used. If so, it tries to find the desired Python interpreter version in the `base_prefix` rather than anywhere on the system's PATH. Note that Windows was not tested, and probably will require some more changes.

### Test Plan

```
# Create and enter virtual environment, then
cd ~/git/nox
pip install -e .
cd ~/git/pipx
# modify pipx's noxfile.py to have `venv_backend='venv'` for the unittests session
nox -s unittests-3.6  # tests pass
```

### Additional context
> prefix: A string giving the site-specific directory prefix where the platform independent Python files are installed

https://docs.python.org/3/library/sys.html#sys.prefix

> base_prefix: Set during Python startup, before site.py is run, to the same value as prefix. If not running in a virtual environment, the values will stay the same; if site.py finds that a virtual environment is in use, the values of prefix and exec_prefix will be changed to point to the virtual environment, whereas base_prefix and base_exec_prefix will remain pointing to the base Python installation (the one which the virtual environment was created from).

https://docs.python.org/3/library/sys.html#sys.base_prefix

Tox's implementation for venv support is included as a plugin in an additional package: https://github.com/tox-dev/tox-venv/blob/master/src/tox_venv/hooks.py

--- 

fixes https://github.com/theacodes/nox/issues/199
cc @pfmoore 