### PR TITLE
Add support for pipenv install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,9 @@ matrix:
   - python: '3.7'
     env: NOXSESSION="docs"
     dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
+  - python: '3.7'
+    env: NOXSESSION="pipenv_tests-3.7"
+    dist: xenial    # required for Python 3.7 (travis-ci/travis-ci#9069)
 before_install:
   - wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
   - chmod +x miniconda.sh
@@ -21,6 +24,7 @@ before_install:
   # Prefer the built-in python binary.
   - export PATH="$PATH:/home/travis/miniconda3/bin"
   - conda update --yes conda
+  - if [[ $NOXSESSION == pipenv_tests* ]]; then pip install pipenv; fi;
 install:
   - pip install --upgrade pip setuptools
   - pip install .

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -269,6 +269,53 @@ class Session:
             **kwargs
         )
 
+    def pipenv_install(self, *args, dev=False, **kwargs):
+        """Install invokes `pipenv install`_ to install packages inside of the
+        session's virtualenv.
+
+        To install packages from a Pipfile::
+
+            session.pipenv_install()
+
+        To install both develop and default packages::
+
+            session.pipenv_install(dev=True)
+
+        To pass extra options to "pipenv install", pass the options as args::
+
+            session.pipenv_install("--pre", "--verbose")
+
+        To install the current package::
+
+            session.pipenv_install('.')
+            # Install in editable mode.
+            session.pipenv_install('-e', '.')
+
+        Additional keyword args are the same as for :meth:`run`.
+
+        .. _pipenv install: https://docs.pipenv.org
+        """
+        if not isinstance(self.virtualenv, VirtualEnv):
+            raise ValueError(
+                "A session without a virtualenv can not install dependencies."
+            )
+
+        if "silent" not in kwargs:
+            kwargs["silent"] = True
+
+        if dev:
+            args = "--dev", *args
+
+        self._run(
+            "pipenv",
+            "install",
+            "--ignore-pipfile",
+            *args,
+            external=True,
+            env={"VIRTUAL_ENV": self.virtualenv.location},
+            **kwargs
+        )
+
     def install(self, *args, **kwargs):
         """Install invokes `pip`_ to install packages inside of the session's
         virtualenv.

--- a/noxfile.py
+++ b/noxfile.py
@@ -42,6 +42,15 @@ def conda_tests(session):
     session.run("pytest", *tests)
 
 
+@nox.session(python=["3.5", "3.6", "3.7"])
+def pipenv_tests(session):
+    """Run tests using Pipenv."""
+    session.pipenv_install("-r", "requirements-test.txt")
+    session.pipenv_install("-e", ".[tox_to_nox]")
+    tests = session.posargs or ["tests/"]
+    session.run("pytest", *tests)
+
+
 @nox.session
 def cover(session):
     """Coverage analysis."""

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -371,6 +371,130 @@ class TestSession:
                 "pip", "install", "requests", "urllib3", silent=False, external="error"
             )
 
+    def test_pipenv_install_not_a_virtualenv(self):
+        session, runner = self.make_session_and_runner()
+
+        runner.venv = None
+
+        with pytest.raises(ValueError, match="virtualenv"):
+            session.pipenv_install()
+
+    def test_pipenv_install(self):
+        runner = nox.sessions.SessionRunner(
+            name="test",
+            signatures=["test"],
+            func=mock.sentinel.func,
+            global_config=_options.options.namespace(posargs=mock.sentinel.posargs),
+            manifest=mock.create_autospec(nox.manifest.Manifest),
+        )
+        runner.venv = mock.create_autospec(nox.virtualenv.VirtualEnv)
+        runner.venv.location = "/path/to/virtualenv"
+        runner.venv.env = {}
+
+        class SessionNoSlots(nox.sessions.Session):
+            pass
+
+        session = SessionNoSlots(runner=runner)
+
+        with mock.patch.object(session, "_run", autospec=True) as run:
+            session.pipenv_install()
+            run.assert_called_once_with(
+                "pipenv",
+                "install",
+                "--ignore-pipfile",
+                silent=True,
+                external=True,
+                env={"VIRTUAL_ENV": "/path/to/virtualenv"},
+            )
+
+    def test_pipenv_install_with_args(self):
+        runner = nox.sessions.SessionRunner(
+            name="test",
+            signatures=["test"],
+            func=mock.sentinel.func,
+            global_config=_options.options.namespace(posargs=mock.sentinel.posargs),
+            manifest=mock.create_autospec(nox.manifest.Manifest),
+        )
+        runner.venv = mock.create_autospec(nox.virtualenv.VirtualEnv)
+        runner.venv.location = "/path/to/virtualenv"
+        runner.venv.env = {}
+
+        class SessionNoSlots(nox.sessions.Session):
+            pass
+
+        session = SessionNoSlots(runner=runner)
+
+        with mock.patch.object(session, "_run", autospec=True) as run:
+            session.pipenv_install("--verbose")
+            run.assert_called_once_with(
+                "pipenv",
+                "install",
+                "--ignore-pipfile",
+                "--verbose",
+                silent=True,
+                external=True,
+                env={"VIRTUAL_ENV": "/path/to/virtualenv"},
+            )
+
+    def test_pipenv_install_with_kwargs(self):
+        runner = nox.sessions.SessionRunner(
+            name="test",
+            signatures=["test"],
+            func=mock.sentinel.func,
+            global_config=_options.options.namespace(posargs=mock.sentinel.posargs),
+            manifest=mock.create_autospec(nox.manifest.Manifest),
+        )
+        runner.venv = mock.create_autospec(nox.virtualenv.VirtualEnv)
+        runner.venv.location = "/path/to/virtualenv"
+        runner.venv.env = {}
+
+        class SessionNoSlots(nox.sessions.Session):
+            pass
+
+        session = SessionNoSlots(runner=runner)
+
+        with mock.patch.object(session, "_run", autospec=True) as run:
+            session.pipenv_install("--verbose", silent=False)
+            run.assert_called_once_with(
+                "pipenv",
+                "install",
+                "--ignore-pipfile",
+                "--verbose",
+                env={"VIRTUAL_ENV": "/path/to/virtualenv"},
+                silent=False,
+                external=True,
+            )
+
+    def test_pipenv_install_with_dev(self):
+        runner = nox.sessions.SessionRunner(
+            name="test",
+            signatures=["test"],
+            func=mock.sentinel.func,
+            global_config=_options.options.namespace(posargs=mock.sentinel.posargs),
+            manifest=mock.create_autospec(nox.manifest.Manifest),
+        )
+        runner.venv = mock.create_autospec(nox.virtualenv.VirtualEnv)
+        runner.venv.location = "/path/to/virtualenv"
+        runner.venv.env = {}
+
+        class SessionNoSlots(nox.sessions.Session):
+            pass
+
+        session = SessionNoSlots(runner=runner)
+
+        with mock.patch.object(session, "_run", autospec=True) as run:
+            session.pipenv_install("--verbose", dev=True)
+            run.assert_called_once_with(
+                "pipenv",
+                "install",
+                "--ignore-pipfile",
+                "--dev",
+                "--verbose",
+                env={"VIRTUAL_ENV": "/path/to/virtualenv"},
+                silent=True,
+                external=True,
+            )
+
     def test_notify(self):
         session, runner = self.make_session_and_runner()
 


### PR DESCRIPTION
This is a very simple wrapper around `pipenv install`. There are a few problems with this though. 
1. I have used `--ignore-pipfile` by default which, if required, I can remove or provide as a kwarg on `pipenv_install()`.
2. Also, I have set `VIRTUAL_ENV` env variable to tell the `pipenv` to use `nox`'s created virtualenv.
3. As I mentioned here: https://github.com/theacodes/nox/issues/159#issuecomment-522216723, this also might update locks, and also have the capability of adding new files. So, only install from `sync`?

The API is a bit bad. But, I guess utilizing nox's virtual environment, with `pipenv`'s, is the best option. But, I'm a novice here, so, please suggest me, and I'll make changes. :slightly_smiling_face: 

P.S. I'm really liking `nox`. And. I wanted to contribute to it. :fireworks: 
I'm going to throw all the `Makefile`s that I have been using in my projects. 

TODO:
- [ ] Update appveyor.yml to run `pipenv_tests`.

Closes #159 