### PR TITLE
Add argcomplete dependency to conda test session.

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -35,7 +35,9 @@ def tests(session):
 @nox.session(python=["3.5", "3.6", "3.7"], venv_backend="conda")
 def conda_tests(session):
     """Run test suite with pytest."""
-    session.conda_install("--file", "requirements-conda-test.txt")
+    session.conda_install(
+        "--file", "requirements-conda-test.txt", "--channel", "conda-forge"
+    )
     session.install("contexter", "--no-deps")
     session.install("-e", ".", "--no-deps")
     tests = session.posargs or ["tests/"]

--- a/requirements-conda-test.txt
+++ b/requirements-conda-test.txt
@@ -1,3 +1,4 @@
+argcomplete >=1.9.4,<2.0
 colorlog >=2.6.1,<4.0.0
 py >=1.4.0,<2.0.0
 virtualenv >=14.0.0


### PR DESCRIPTION
Towards #234 

The `argcomplete` dependency was added in #228, but not to the conda dependencies, which broke the `conda_tests` sessions (not currently tested from CI, as it just runs the same tests as in the `tests` sessions, but downloading dependencies via conda, instead.