### PR TITLE
replace flake8 sorter with isort

### DIFF
--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -23,9 +23,7 @@ import sys
 
 import pkg_resources
 
-from nox import _options
-from nox import tasks
-from nox import workflow
+from nox import _options, tasks, workflow
 from nox.logger import setup_logging
 
 

--- a/nox/command.py
+++ b/nox/command.py
@@ -16,7 +16,6 @@ import os
 import sys
 
 import py  # type: ignore
-
 from nox.logger import logger
 from nox.popen import popen
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -19,9 +19,8 @@ import re
 import sys
 import unicodedata
 
-import py  # type: ignore
-
 import nox.command
+import py  # type: ignore
 from nox.logger import logger
 from nox.virtualenv import CondaEnv, ProcessEnv, VirtualEnv
 

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -17,9 +17,8 @@ import io
 import json
 import os
 
-from colorlog.escape_codes import parse_colors  # type: ignore
-
 import nox
+from colorlog.escape_codes import parse_colors  # type: ignore
 from nox import _options, registry
 from nox.logger import logger
 from nox.manifest import Manifest

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -20,8 +20,7 @@ import os
 from colorlog.escape_codes import parse_colors  # type: ignore
 
 import nox
-from nox import _options
-from nox import registry
+from nox import _options, registry
 from nox.logger import logger
 from nox.manifest import Manifest
 

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -18,9 +18,8 @@ import re
 import shutil
 import sys
 
-import py  # type: ignore
-
 import nox.command
+import py  # type: ignore
 from nox.logger import logger
 
 # Problematic environment variables that are stripped from all commands inside

--- a/noxfile.py
+++ b/noxfile.py
@@ -58,7 +58,7 @@ def cover(session):
 @nox.session(python="3.7")
 def blacken(session):
     """Run black code formater."""
-    session.install("black", "isort==4.3.21")
+    session.install("black==19.3b0", "isort==4.3.21")
     files = ["nox", "tests", "noxfile.py", "setup.py"]
     session.run("black", *files)
     session.run("isort", "--recursive", *files)
@@ -66,7 +66,7 @@ def blacken(session):
 
 @nox.session(python="3.7")
 def lint(session):
-    session.install("flake8", "black", "mypy")
+    session.install("flake8==3.7.8", "black==19.3b0", "mypy==0.720")
     session.run("mypy", "nox")
     files = ["nox", "tests", "noxfile.py", "setup.py"]
     session.run("black", "--check", *files)

--- a/noxfile.py
+++ b/noxfile.py
@@ -66,11 +66,10 @@ def blacken(session):
 
 @nox.session(python="3.7")
 def lint(session):
-    session.install("flake8", "isort==4.3.21", "black", "mypy")
+    session.install("flake8", "black", "mypy")
     session.run("mypy", "nox")
     files = ["nox", "tests", "noxfile.py", "setup.py"]
     session.run("black", "--check", *files)
-    session.run("isort", "--recursive", "--check", *files)
     session.run("flake8", "nox", *files)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -65,10 +65,11 @@ def blacken(session):
 
 @nox.session(python="3.7")
 def lint(session):
-    session.install("flake8", "flake8-import-order", "black", "mypy")
+    session.install("flake8", "isort", "black", "mypy")
     session.run("mypy", "nox")
     session.run("black", "--check", "nox", "tests", "noxfile.py", "setup.py")
     session.run("flake8", "nox", "tests")
+    session.run("isort", "--recursive", "--check", "nox")
 
 
 @nox.session(python="3.7")

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,7 +16,6 @@ import os
 
 import nox
 
-
 ON_APPVEYOR = os.environ.get("APPVEYOR") == "True"
 
 
@@ -59,17 +58,20 @@ def cover(session):
 @nox.session(python="3.7")
 def blacken(session):
     """Run black code formater."""
-    session.install("black")
-    session.run("black", "nox", "tests", "noxfile.py", "setup.py")
+    session.install("black", "isort")
+    files = ["nox", "tests", "noxfile.py", "setup.py"]
+    session.run("black", *files)
+    session.run("isort", "--recursive", *files)
 
 
 @nox.session(python="3.7")
 def lint(session):
     session.install("flake8", "isort", "black", "mypy")
     session.run("mypy", "nox")
-    session.run("black", "--check", "nox", "tests", "noxfile.py", "setup.py")
-    session.run("flake8", "nox", "tests")
-    session.run("isort", "--recursive", "--check", "nox")
+    files = ["nox", "tests", "noxfile.py", "setup.py"]
+    session.run("black", "--check", *files)
+    session.run("isort", "--recursive", "--check", *files)
+    session.run("flake8", "nox", *files)
 
 
 @nox.session(python="3.7")

--- a/noxfile.py
+++ b/noxfile.py
@@ -58,7 +58,7 @@ def cover(session):
 @nox.session(python="3.7")
 def blacken(session):
     """Run black code formater."""
-    session.install("black", "isort")
+    session.install("black", "isort==4.3.21")
     files = ["nox", "tests", "noxfile.py", "setup.py"]
     session.run("black", *files)
     session.run("isort", "--recursive", *files)
@@ -66,7 +66,7 @@ def blacken(session):
 
 @nox.session(python="3.7")
 def lint(session):
-    session.install("flake8", "isort", "black", "mypy")
+    session.install("flake8", "isort==4.3.21", "black", "mypy")
     session.run("mypy", "nox")
     files = ["nox", "tests", "noxfile.py", "setup.py"]
     session.run("black", "--check", *files)

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ from codecs import open
 
 from setuptools import setup
 
-
 long_description = open("README.rst", "r", encoding="utf-8").read()
 
 

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -16,10 +16,7 @@ import sys
 from unittest import mock
 
 import pytest
-
-from nox import _option_set
-from nox import _options
-
+from nox import _option_set, _options
 
 # The vast majority of _option_set is tested by test_main, but the test helper
 # :func:`OptionSet.namespace` needs a bit of help to get to full coverage.

--- a/tests/test__parametrize.py
+++ b/tests/test__parametrize.py
@@ -15,7 +15,6 @@
 from unittest import mock
 
 import pytest
-
 from nox import _parametrize
 
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -17,9 +17,8 @@ import os
 import sys
 from unittest import mock
 
-import pytest
-
 import nox.command
+import pytest
 
 PYTHON = sys.executable
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,16 +16,15 @@ import os
 import sys
 from unittest import mock
 
-import contexter
 import pkg_resources
-import pytest
 
+import contexter
 import nox
 import nox.__main__
 import nox._options
 import nox.registry
 import nox.sessions
-
+import pytest
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 VERSION = pkg_resources.get_distribution("nox").version

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -15,11 +15,9 @@
 import collections
 from unittest import mock
 
-import pytest
-
 import nox
-from nox.manifest import _null_session_func
-from nox.manifest import Manifest
+import pytest
+from nox.manifest import Manifest, _null_session_func
 
 
 def create_mock_sessions():

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 import pytest
-
 from nox import registry
 
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -18,15 +18,14 @@ import os
 import sys
 from unittest import mock
 
-import pytest
-
-from nox import _options
 import nox.command
-from nox.logger import logger
 import nox.manifest
 import nox.registry
 import nox.sessions
 import nox.virtualenv
+import pytest
+from nox import _options
+from nox.logger import logger
 
 
 def test__normalize_path():

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -20,14 +20,10 @@ import os
 import platform
 from unittest import mock
 
-import pytest
-
 import nox
-from nox import _options
-from nox import sessions
-from nox import tasks
+import pytest
+from nox import _options, sessions, tasks
 from nox.manifest import Manifest
-
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 

--- a/tests/test_tox_to_nox.py
+++ b/tests/test_tox_to_nox.py
@@ -16,7 +16,6 @@ import sys
 import textwrap
 
 import pytest
-
 from nox import tox_to_nox
 
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -17,11 +17,9 @@ import shutil
 import sys
 from unittest import mock
 
+import nox.virtualenv
 import py
 import pytest
-
-import nox.virtualenv
-
 
 IS_WINDOWS = nox.virtualenv._SYSTEM == "Windows"
 HAS_CONDA = shutil.which("conda") is not None


### PR DESCRIPTION
There is no easy way to automatically satisfy flake8's linting requirements for sort order. Using isort there is.

I ran 
```
isort --recursive nox
```
to automatically sort imports. Then I updated noxfile to test with isort rather than flake8.