### PR TITLE
Pass VIRTUAL_ENV environment variable to commands

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -236,7 +236,7 @@ class VirtualEnv(ProcessEnv):
         self._resolved = None
         self.reuse_existing = reuse_existing
         self.venv_or_virtualenv = "venv" if venv else "virtualenv"
-        super(VirtualEnv, self).__init__()
+        super(VirtualEnv, self).__init__(env={"VIRTUAL_ENV": self.location})
 
     _clean_location = _clean_location
 


### PR DESCRIPTION
Add the `VIRTUAL_ENV` variable to the process environment of commands executed in a nox session. The value of this variable contains the location of the virtualenv created by nox. 

Closes #159

**Rationale**

Some commands rely on the presence of the `VIRTUAL_ENV` variable in their environment to detect that they are running in a virtualenv. In particular, [poetry](https://poetry.eustace.io) and [pipenv](https://github.com/pypa/pipenv) will only install packages into the virtualenv if its location is passed to them via this variable. Without that variable, these commands will create their own virtualenv for the project, breaking session isolation.

The `VIRTUAL_ENV` variable is set in the user's shell by the `bin/activate` scripts provided with virtual environments created by `virtualenv` and the core `venv` module. In the case of nox, commands run in a session are not executed within a shell. So the variable needs to be provided to the command by nox itself.

The `VIRTUAL_ENV` variable is not (AFAICT) prescribed by any PEP, but it is mentioned in [PEP 486](https://www.python.org/dev/peps/pep-0486/) and used in the implementation of the standard `venv` module.

**Implementation**

The variable is added to the `env` attribute of `VirtualEnv` instances. It will be available to commands created by the `session.run` and `session.install` functions, through `session.env` which references the virtualenv created by the `SessionRunner`.

**Limitations**

This change is only applied to virtual environments (`VirtualEnv`), not to conda environments (`CondaEnv`), because I am not familiar with them.