### PR TITLE
Use double ` for inline code

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -4,7 +4,7 @@ Configuration & API
 Noxfile
 -------
 
-Nox looks for configuration in a file named `noxfile.py` by default. You can specify
+Nox looks for configuration in a file named ``noxfile.py`` by default. You can specify
 a different file using the ``--noxfile`` argument when running ``nox``.
 
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -36,7 +36,7 @@ To list all available sessions, including parametrized sessions:
 Running all sessions
 --------------------
 
-You can run every session by just executing `nox` without any arguments:
+You can run every session by just executing ``nox`` without any arguments:
 
 .. code-block:: console
 
@@ -264,8 +264,8 @@ However, this will never output colorful logs:
 Controling commands verbosity
 -----------------------------
 
-By default, Nox will only show output of commands that fail, or, when the commands get passed `silent=False`.
-By passing `--verbose` to Nox, all output of all commands run is shown, regardless of the silent argument.
+By default, Nox will only show output of commands that fail, or, when the commands get passed ``silent=False``.
+By passing ``--verbose`` to Nox, all output of all commands run is shown, regardless of the silent argument.
 
 
 Outputting a machine-readable report

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -231,7 +231,7 @@ class Session:
             session.conda_install('numpy', 'scipy')
             session.conda_install('--channel=conda-forge', 'dask==2.1.0')
 
-        To install packages from a `requirements.txt` file::
+        To install packages from a ``requirements.txt`` file::
 
             session.conda_install('--file', 'requirements.txt')
             session.conda_install('--file', 'requirements-dev.txt')
@@ -278,7 +278,7 @@ class Session:
             session.install('requests', 'mock')
             session.install('requests[security]==2.9.1')
 
-        To install packages from a `requirements.txt` file::
+        To install packages from a ``requirements.txt`` file::
 
             session.install('-r', 'requirements.txt')
             session.install('-r', 'requirements-dev.txt')


### PR DESCRIPTION
This was causing a weird thing here https://nox.thea.codes/en/latest/usage.html#controling-commands-verbosity
(replacing the `--` for an en-dash).

I searched the whole docs and docstrings.