### PR TITLE
appveyor.yml: Order Pythons in descending version

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -65,7 +65,7 @@ install:
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
-  - "pip install wheel"
+  - "python -m pip install wheel"
 
 # init:
 #   - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
@@ -74,7 +74,7 @@ install:
 #   - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 build_script:
-  - "pip install ."
+  - "python -m pip install ."
 
 test_script:
   # Run the project tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,22 +10,6 @@ environment:
     # a later point release.
     # See: http://www.appveyor.com/docs/installed-software#python
 
-    - PYTHON: "C:\\Python35"
-      CONDA: "C:\\Miniconda35"
-      NOX_SESSION: "tests-3.5"
-
-    - PYTHON: "C:\\Python35-x64"
-      CONDA: "C:\\Miniconda35-x64"
-      NOX_SESSION: "tests-3.5"
-
-    - PYTHON: "C:\\Python36"
-      CONDA: "C:\\Miniconda36"
-      NOX_SESSION: "tests-3.6"
-
-    - PYTHON: "C:\\Python36-x64"
-      CONDA: "C:\\Miniconda36-x64"
-      NOX_SESSION: "tests-3.6"
-
     - PYTHON: "C:\\Python37"
       # Python 3.7 conda installation appears to be broken on Appveyor:
       # TypeError: LoadLibrary() argument 1 must be str, not None
@@ -37,6 +21,22 @@ environment:
       # TypeError: LoadLibrary() argument 1 must be str, not None
       CONDA: "C:\\Miniconda36-x64"
       NOX_SESSION: "tests-3.7"
+
+    - PYTHON: "C:\\Python36"
+      CONDA: "C:\\Miniconda36"
+      NOX_SESSION: "tests-3.6"
+
+    - PYTHON: "C:\\Python36-x64"
+      CONDA: "C:\\Miniconda36-x64"
+      NOX_SESSION: "tests-3.6"
+
+    - PYTHON: "C:\\Python35"
+      CONDA: "C:\\Miniconda35"
+      NOX_SESSION: "tests-3.5"
+
+    - PYTHON: "C:\\Python35-x64"
+      CONDA: "C:\\Miniconda35-x64"
+      NOX_SESSION: "tests-3.5"
 
 install:
   # Add conda command to path.


### PR DESCRIPTION
This ordering helps identify when a problem occurs only
in older versions of Python, as AppVeyor fail-fast means
failures in the early jobs prevent seeing if latter jobs
would have succeeded.