### PR TITLE
install cache to avoid frequent pip installs...

### DIFF
--- a/nox/_options.py
+++ b/nox/_options.py
@@ -209,6 +209,13 @@ options.add_options(
         help="Re-use existing virtualenvs instead of recreating them.",
     ),
     _option_set.Option(
+        "install_cache",
+        "--install-cache",
+        noxfile=True,
+        group="secondary",
+        help="How often to skip succesful install calls (in minutes)",
+    ),
+    _option_set.Option(
         "noxfile",
         "-f",
         "--noxfile",

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,21 @@
+
+from nox.sessions import InstallCache
+def test_cache_empty(tmpdir):
+    ic = InstallCache()
+    ic.destroy(".")
+    assert not ic.check(".", [1,2,3], 50)
+    
+    
+from nox.sessions import InstallCache
+def test_cache_good(tmpdir):
+    ic = InstallCache()
+    ic.add(".", [1,2,3])
+    ic2 = InstallCache()
+    assert ic2.check(".", [1,2,3], 50)
+    
+from nox.sessions import InstallCache
+def test_cache_stale(tmpdir):
+    ic = InstallCache()
+    ic.add(".", [1,2,3])
+    ic2 = InstallCache()
+    assert not ic2.check(".", [1,2,3], -50)


### PR DESCRIPTION
this creates a feature to avoid running pip all the time.  This does it by creating a state file inside the root of the venv to cache when the last good run of the pip command (with those arguments) was run.

For example a cache file will look like this:
```
$ more .nox/test-3-6/.nox_install_cache 
{"[\"--upgrade\",\"-r\",\"test-requirements.txt\"]":1574446974}
```
There are three ways to set this 

- globally on the command line: `    nox -install-cache 10`
- globally inside the noxfile.py:  `  nox.options.install_cache="10"`
- per individual session invocations:      ` session.install("--upgrade", "-r", "test-requirements.txt", nox_install_cache="10")`

I'm sure there's some tidying to do before this is accepted, my list:

1. Where should the code for the InstallCache object reside (currently in sessions.py)?
2. How to preserve the InstallCache instance  (currently creating it from scrach every `Session.install()` invocation)
3. surely there are more error case to code for (corrupt cache files, invalid setting types, etc).