### PR TITLE
Use stdout.isatty to finalize color

### DIFF
--- a/nox/_options.py
+++ b/nox/_options.py
@@ -96,7 +96,7 @@ def _color_finalizer(value, args):
     if args.nocolor is True:
         return False
 
-    return sys.stdin.isatty()
+    return sys.stdout.isatty()
 
 
 def _posargs_finalizer(value, args):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -379,7 +379,7 @@ def test_main_color_from_isatty(monkeypatch, isatty_value, expected):
     monkeypatch.setattr(sys, "argv", [sys.executable])
     with mock.patch("nox.workflow.execute") as execute:
         execute.return_value = 0
-        with mock.patch("sys.stdin.isatty") as isatty:
+        with mock.patch("sys.stdout.isatty") as isatty:
             isatty.return_value = isatty_value
 
             # Call the main function.


### PR DESCRIPTION
Currently checks stdin
Fixes #266 