### PR TITLE
enable type hints when importing nox

### DIFF
--- a/nox/py.typed
+++ b/nox/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561.  The nox package uses inline types.

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,9 @@ setup(
     ],
     keywords="testing automation tox",
     packages=["nox"],
+    package_data={"nox": ["py.typed"]},
     include_package_data=True,
+    zip_safe=False,
     install_requires=[
         "argcomplete>=1.9.4,<2.0",
         "colorlog>=2.6.1,<5.0.0",


### PR DESCRIPTION
Because nox is not marked as containing type hints, any libraries that import nox will get a mypy error saying the library is untyped. To fix this, users have had to do

```
import nox  # type: ignore
```

to avoid errors such as
```
error: Cannot find implementation or library stub for module named 'nox'
note: See https://mypy.readthedocs.io/en/latest/running_mypy.html#missing-imports
```

This PR implements instructions in the mypy documentation to tell mypy that nox does indeed have inline types (https://mypy.readthedocs.io/en/latest/installed_packages.html#making-pep-561-compatible-packages). Though rather strange and arbitrary, this is the standard way to do this. GvR himself committed a py.typed to mypy [here](https://github.com/python/mypy/blob/master/mypy/py.typed).

If this code is merged, the `# type: ignore` comment will no longer be necessary for users of nox, and they can be confident their code doesn't have type errors.