### PR TITLE
Fix typo in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 2019.11.4
+## 2019.11.9
 
 - Fix example installation call for pip. (#259)
 - Allow colorlog 4. (#257)


### PR DESCRIPTION
The latest version is 2019.11.9 not 2019.11.4.