### PR TITLE
Upgrade typehints to support disallow-untyped-defs flag

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,9 @@
 [run]
 branch = True
+omit =
+    nox/_typing.py
 
 [report]
 exclude_lines =
     pragma: no cover
+    if _typing.TYPE_CHECKING:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.mypy_cache/
+.vscode/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,6 @@
+[settings]
+multi_line_output=3
+include_trailing_comma=True
+force_grid_wrap=0
+use_parentheses=True
+line_length=88

--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -21,13 +21,13 @@ control to :meth:``nox.workflow.execute``.
 
 import sys
 
+from nox import _options, tasks, workflow
+from nox.logger import setup_logging
+
 try:
     import importlib.metadata as metadata  # type: ignore
 except ImportError:  # pragma: no cover
     import importlib_metadata as metadata  # type: ignore
-
-from nox import _options, tasks, workflow
-from nox.logger import setup_logging
 
 
 def main() -> None:

--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -27,7 +27,7 @@ from nox import _options, tasks, workflow
 from nox.logger import setup_logging
 
 
-def main():
+def main() -> None:
     args = _options.options.parse_args()
 
     if args.help:

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -21,7 +21,7 @@ import argparse
 import collections
 import functools
 from argparse import ArgumentError, ArgumentParser, Namespace, _ArgumentGroup
-from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple, Union
+from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 
 import argcomplete  # type: ignore
 
@@ -60,19 +60,19 @@ class Option:
     def __init__(
         self,
         name: str,
-        *flags,
-        help: str = None,
-        group: str = None,
+        *flags: str,
+        help: Optional[str] = None,
+        group: Optional[str] = None,
         noxfile: bool = False,
-        merge_func: Callable[[Namespace, Namespace], Any] = None,
-        finalizer_func: Callable[[Any, Namespace], Any] = None,
+        merge_func: Optional[Callable[[Namespace, Namespace], Any]] = None,
+        finalizer_func: Optional[Callable[[Any, Namespace], Any]] = None,
         default: Union[Any, Callable[[], Any]] = None,
         hidden: bool = False,
-        completer: Callable[..., List[str]] = None,
-        **kwargs
+        completer: Optional[Callable[..., List[str]]] = None,
+        **kwargs: Any
     ) -> None:
         self.name = name
-        self.flags = flags  # type: Sequence[str]
+        self.flags = flags
         self.help = help
         self.group = group
         self.noxfile = noxfile
@@ -80,7 +80,7 @@ class Option:
         self.finalizer_func = finalizer_func
         self.hidden = hidden
         self.completer = completer
-        self.kwargs = kwargs  # type: Dict[str, Any]
+        self.kwargs = kwargs
         self._default = default
 
     @property
@@ -140,7 +140,7 @@ def make_flag_pair(
     name: str,
     enable_flags: Union[Tuple[str, str], Tuple[str]],
     disable_flags: Tuple[str],
-    **kwargs
+    **kwargs: Any
 ) -> Tuple[Option, Option]:
     """Returns two options - one to enable a behavior and another to disable it.
 
@@ -174,15 +174,17 @@ class OptionSet:
     finalization, callable defaults, and strongly typed namespaces for tests.
     """
 
-    def __init__(self, *args, **kwargs) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         self.parser_args = args
         self.parser_kwargs = kwargs
-        self.options = collections.OrderedDict()  # type: Dict[str, Option]
+        self.options = (
+            collections.OrderedDict()
+        )  # type: collections.OrderedDict[str, Option]
         self.groups = (
             collections.OrderedDict()
-        )  # type: Dict[str, Tuple[Tuple[Any, ...], Dict[str, Any]]]
+        )  # type: collections.OrderedDict[str, Tuple[Tuple[Any, ...], Dict[str, Any]]]
 
-    def add_options(self, *args) -> None:
+    def add_options(self, *args: Option) -> None:
         """Adds a sequence of Options to the OptionSet.
 
         Args:
@@ -191,7 +193,7 @@ class OptionSet:
         for option in args:
             self.options[option.name] = option
 
-    def add_group(self, name: str, *args, **kwargs) -> None:
+    def add_group(self, name: str, *args: Any, **kwargs: Any) -> None:
         """Adds a new argument group.
 
         When :func:`parser` is invoked, the OptionSet will turn all distinct
@@ -233,7 +235,7 @@ class OptionSet:
 
         return parser
 
-    def print_help(self):
+    def print_help(self) -> None:
         return self.parser().print_help()
 
     def _finalize_args(self, args: Namespace) -> None:
@@ -260,7 +262,7 @@ class OptionSet:
             parser.error(str(err))
         return args
 
-    def namespace(self, **kwargs):
+    def namespace(self, **kwargs: Any) -> argparse.Namespace:
         """Return a namespace that contains all of the options in this set.
 
         kwargs can be used to set values and does so in a checked way - you

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -16,7 +16,7 @@ import argparse
 import functools
 import os
 import sys
-from typing import List
+from typing import Any, List, Optional, Sequence, Union
 
 from nox import _option_set
 from nox.tasks import discover_manifest, filter_manifest, load_nox_module
@@ -39,7 +39,9 @@ options.add_group(
 )
 
 
-def _sessions_and_keywords_merge_func(key, command_args, noxfile_args):
+def _sessions_and_keywords_merge_func(
+    key: str, command_args: argparse.Namespace, noxfile_args: argparse.Namespace
+) -> List[str]:
     """Only return the Noxfile value for sessions/keywords if neither sessions
     or keywords are specified on the command-line.
 
@@ -56,7 +58,9 @@ def _sessions_and_keywords_merge_func(key, command_args, noxfile_args):
     return getattr(command_args, key)
 
 
-def _envdir_merge_func(command_args, noxfile_args):
+def _envdir_merge_func(
+    command_args: argparse.Namespace, noxfile_args: argparse.Namespace
+) -> str:
     """Ensure that there is always some envdir.
 
     Args:
@@ -68,14 +72,14 @@ def _envdir_merge_func(command_args, noxfile_args):
     return command_args.envdir or noxfile_args.envdir or ".nox"
 
 
-def _sessions_default():
+def _sessions_default() -> Optional[List[str]]:
     """Looks at the NOXSESSION env var to set the default value for sessions."""
     nox_env = os.environ.get("NOXSESSION")
     env_sessions = nox_env.split(",") if nox_env else None
     return env_sessions
 
 
-def _color_finalizer(value, args):
+def _color_finalizer(value: bool, args: argparse.Namespace) -> bool:
     """Figures out the correct value for "color" based on the two color flags.
 
     Args:
@@ -99,7 +103,9 @@ def _color_finalizer(value, args):
     return sys.stdout.isatty()
 
 
-def _posargs_finalizer(value, args):
+def _posargs_finalizer(
+    value: Sequence[Any], args: argparse.Namespace
+) -> Union[Sequence[Any], List[Any]]:
     """Removes the leading "--"s in the posargs array (if any) and asserts that
     remaining arguments came after a "--".
     """
@@ -124,11 +130,11 @@ def _posargs_finalizer(value, args):
 
 
 def _session_completer(
-    prefix: str, parsed_args: argparse.Namespace, **kwargs
+    prefix: str, parsed_args: argparse.Namespace, **kwargs: Any
 ) -> List[str]:
     global_config = parsed_args
     module = load_nox_module(global_config)
-    manifest = discover_manifest(module, global_config)
+    manifest = discover_manifest(module, global_config)  # type: ignore
     filtered_manifest = filter_manifest(manifest, global_config)
     if isinstance(filtered_manifest, int):
         return []

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -14,8 +14,7 @@
 
 import functools
 import itertools
-from typing import (Any, Callable, Dict, Iterable, List, Optional, Sequence,
-                    Tuple, Union)
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
 
 class Param:

--- a/nox/_typing.py
+++ b/nox/_typing.py
@@ -1,0 +1,17 @@
+__all__ = ["TYPE_CHECKING", "NoReturn"]
+
+try:
+    from typing import TYPE_CHECKING
+except ImportError:
+    try:
+        from typing_extensions import TYPE_CHECKING
+    except ImportError:
+        TYPE_CHECKING = False
+
+try:
+    from typing import NoReturn
+except ImportError:
+    try:
+        from typing_extensions import NoReturn
+    except ImportError:
+        pass

--- a/nox/command.py
+++ b/nox/command.py
@@ -14,6 +14,7 @@
 
 import os
 import sys
+from typing import Any, Iterable, Optional, Sequence, Union
 
 import py  # type: ignore
 from nox.logger import logger
@@ -23,12 +24,12 @@ from nox.popen import popen
 class CommandFailed(Exception):
     """Raised when an executed command returns a non-success status code."""
 
-    def __init__(self, reason=None):
+    def __init__(self, reason: str = None) -> None:
         super(CommandFailed, self).__init__(reason)
         self.reason = reason
 
 
-def which(program, path):
+def which(program: str, path: Optional[str]) -> str:
     """Finds the full path to an executable."""
     full_path = None
 
@@ -47,7 +48,7 @@ def which(program, path):
     raise CommandFailed("Program {} not found".format(program))
 
 
-def _clean_env(env):
+def _clean_env(env: Optional[dict]) -> Optional[dict]:
     if env is None:
         return None
 
@@ -61,16 +62,16 @@ def _clean_env(env):
 
 
 def run(
-    args,
+    args: Sequence[str],
     *,
-    env=None,
-    silent=False,
-    path=None,
-    success_codes=None,
-    log=True,
-    external=False,
-    **popen_kws
-):
+    env: Optional[dict] = None,
+    silent: bool = False,
+    path: Optional[str] = None,
+    success_codes: Optional[Iterable[int]] = None,
+    log: bool = True,
+    external: bool = False,
+    **popen_kws: Any
+) -> Union[str, bool]:
     """Run a command-line program."""
 
     if success_codes is None:

--- a/nox/logger.py
+++ b/nox/logger.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import logging
+from typing import Any, cast
 
 from colorlog import ColoredFormatter  # type: ignore
 
@@ -21,29 +22,29 @@ OUTPUT = logging.DEBUG - 1
 
 
 class NoxFormatter(ColoredFormatter):
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super(NoxFormatter, self).__init__(*args, **kwargs)
         self._simple_fmt = logging.Formatter("%(message)s")
 
-    def format(self, record):
+    def format(self, record: Any) -> str:
         if record.levelname == "OUTPUT":
             return self._simple_fmt.format(record)
         return super(NoxFormatter, self).format(record)
 
 
 class LoggerWithSuccessAndOutput(logging.getLoggerClass()):  # type: ignore
-    def __init__(self, name, level=logging.NOTSET):
+    def __init__(self, name: str, level: int = logging.NOTSET):
         super(LoggerWithSuccessAndOutput, self).__init__(name, level)
         logging.addLevelName(SUCCESS, "SUCCESS")
         logging.addLevelName(OUTPUT, "OUTPUT")
 
-    def success(self, msg, *args, **kwargs):
+    def success(self, msg: str, *args: Any, **kwargs: Any) -> None:
         if self.isEnabledFor(SUCCESS):
             self._log(SUCCESS, msg, args, **kwargs)
         else:  # pragma: no cover
             pass
 
-    def output(self, msg, *args, **kwargs):
+    def output(self, msg: str, *args: Any, **kwargs: Any) -> None:
         if self.isEnabledFor(OUTPUT):
             self._log(OUTPUT, msg, args, **kwargs)
         else:  # pragma: no cover
@@ -51,10 +52,10 @@ class LoggerWithSuccessAndOutput(logging.getLoggerClass()):  # type: ignore
 
 
 logging.setLoggerClass(LoggerWithSuccessAndOutput)
-logger = logging.getLogger("nox")
+logger = cast(LoggerWithSuccessAndOutput, logging.getLogger("nox"))
 
 
-def setup_logging(color, verbose=False):  # pragma: no cover
+def setup_logging(color: bool, verbose: bool = False) -> None:  # pragma: no cover
     """Setup logging.
 
     Args:

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -17,8 +17,7 @@ import copy
 import functools
 import itertools
 import types
-from typing import (Any, Callable, Iterable, Iterator, List, Mapping, Set,
-                    Tuple, Union)
+from typing import Any, Callable, Iterable, Iterator, List, Mapping, Set, Tuple, Union
 
 from nox._parametrize import generate_calls
 from nox.sessions import Session, SessionRunner

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -14,9 +14,16 @@
 
 import subprocess
 import sys
+from typing import IO, Mapping, Sequence, Tuple, Union
 
 
-def popen(args, env=None, silent=False, stdout=None, stderr=subprocess.STDOUT):
+def popen(
+    args: Sequence[str],
+    env: Mapping[str, str] = None,
+    silent: bool = False,
+    stdout: Union[int, IO] = None,
+    stderr: Union[int, IO] = subprocess.STDOUT,
+) -> Tuple[int, str]:
     if silent and stdout is not None:
         raise ValueError(
             "Can not specify silent and stdout; passing a custom stdout always silences the commands output in Nox's log."

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -15,13 +15,20 @@
 import collections
 import copy
 import functools
+from typing import Any, Callable, Optional, Sequence, Union
 
-_REGISTRY = collections.OrderedDict()  # type: ignore
+_REGISTRY = collections.OrderedDict()  # type: collections.OrderedDict[str, Callable]
+Python = Optional[Union[str, Sequence[str], bool]]
 
 
 def session_decorator(
-    func=None, python=None, py=None, reuse_venv=None, name=None, venv_backend=None
-):
+    func: Optional[Callable] = None,
+    python: Python = None,
+    py: Python = None,
+    reuse_venv: Optional[bool] = None,
+    name: Optional[str] = None,
+    venv_backend: Any = None,
+) -> Callable:
     """Designate the decorated function as a session."""
     # If `func` is provided, then this is the decorator call with the function
     # being sent as part of the Python syntax (`@nox.session`).
@@ -49,15 +56,15 @@ def session_decorator(
     if python is None:
         python = py
 
-    func.python = python
-    func.reuse_venv = reuse_venv
-    func.venv_backend = venv_backend
+    func.python = python  # type: ignore
+    func.reuse_venv = reuse_venv  # type: ignore
+    func.venv_backend = venv_backend  # type: ignore
     _REGISTRY[name or func.__name__] = func
 
     return func
 
 
-def get():
+def get() -> "collections.OrderedDict[str, Callable]":
     """Return a shallow copy of the registry.
 
     This ensures that the registry is not accidentally modified by

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -408,7 +408,7 @@ class SessionRunner:
                 interpreter=self.func.python,  # type: ignore
                 reuse_existing=reuse_existing,
                 venv=True,
-                venv_params=self.func.venv_params,
+                venv_params=self.func.venv_params,  # type: ignore
             )
         else:
             raise ValueError(

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -19,8 +19,17 @@ import os
 import re
 import sys
 import unicodedata
-from typing import (Any, Callable, Dict, Iterable, List, Mapping, Optional,
-                    Sequence, Union)
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Iterable,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Union,
+)
 
 import nox.command
 import py  # type: ignore

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -12,20 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
 import enum
 import hashlib
 import os
 import re
 import sys
 import unicodedata
+from typing import (Any, Callable, Dict, Iterable, List, Mapping, Optional,
+                    Sequence, Union)
 
 import nox.command
 import py  # type: ignore
+from nox import _typing
 from nox.logger import logger
 from nox.virtualenv import CondaEnv, ProcessEnv, VirtualEnv
 
+if _typing.TYPE_CHECKING:
+    from nox.manifest import Manifest
 
-def _normalize_path(envdir, path):
+
+def _normalize_path(envdir: str, path: Union[str, bytes]) -> str:
     """Normalizes a string to be a "safe" filesystem path for a virtualenv."""
     if isinstance(path, bytes):
         path = path.decode("utf-8")
@@ -76,11 +83,11 @@ class Session:
 
     __slots__ = ("_runner",)
 
-    def __init__(self, runner):
+    def __init__(self, runner: "SessionRunner") -> None:
         self._runner = runner
 
     @property
-    def __dict__(self):
+    def __dict__(self) -> "Dict[str, SessionRunner]":  # type: ignore
         """Attribute dictionary for object inspection.
 
         This is needed because ``__slots__`` turns off ``__dict__`` by
@@ -90,37 +97,37 @@ class Session:
         return {"_runner": self._runner}
 
     @property
-    def env(self):
+    def env(self) -> dict:
         """A dictionary of environment variables to pass into all commands."""
-        return self._runner.venv.env
+        return self._runner.venv.env  # type: ignore
 
     @property
-    def posargs(self):
+    def posargs(self) -> List[str]:
         """This is set to any extra arguments
         passed to ``nox`` on the commandline."""
         return self._runner.global_config.posargs
 
     @property
-    def virtualenv(self):
+    def virtualenv(self) -> Optional[ProcessEnv]:
         """The virtualenv that all commands are run in."""
         return self._runner.venv
 
     @property
-    def python(self):
+    def python(self) -> Optional[Union[str, Sequence[str], bool]]:
         """The python version passed into ``@nox.session``."""
-        return self._runner.func.python
+        return self._runner.func.python  # type: ignore
 
     @property
-    def bin(self):
+    def bin(self) -> str:
         """The bin directory for the virtualenv."""
-        return self._runner.venv.bin
+        return self._runner.venv.bin  # type: ignore
 
     @property
-    def interactive(self):
+    def interactive(self) -> bool:
         """Returns True if Nox is being run in an interactive session or False otherwise."""
         return not self._runner.global_config.non_interactive and sys.stdin.isatty()
 
-    def chdir(self, dir):
+    def chdir(self, dir: str) -> None:
         """Change the current working directory."""
         self.log("cd {}".format(dir))
         os.chdir(dir)
@@ -128,7 +135,9 @@ class Session:
     cd = chdir
     """An alias for :meth:`chdir`."""
 
-    def _run_func(self, func, args, kwargs):
+    def _run_func(
+        self, func: Callable, args: Iterable[Any], kwargs: Mapping[str, Any]
+    ) -> Any:
         """Legacy support for running a function through :func`run`."""
         self.log("{}(args={!r}, kwargs={!r})".format(func, args, kwargs))
         try:
@@ -137,7 +146,9 @@ class Session:
             logger.exception("Function {!r} raised {!r}.".format(func, e))
             raise nox.command.CommandFailed()
 
-    def run(self, *args, env=None, **kwargs):
+    def run(
+        self, *args: str, env: Mapping[str, str] = None, **kwargs: Any
+    ) -> Optional[Any]:
         """Run a command.
 
         Commands must be specified as a list of strings, for example::
@@ -189,11 +200,11 @@ class Session:
 
         if self._runner.global_config.install_only:
             logger.info("Skipping {} run, as --install-only is set.".format(args[0]))
-            return
+            return None
 
         return self._run(*args, env=env, **kwargs)
 
-    def _run(self, *args, env=None, **kwargs):
+    def _run(self, *args: str, env: Mapping[str, str] = None, **kwargs: Any) -> Any:
         """Like run(), except that it runs even if --install-only is provided."""
         # Legacy support - run a function given.
         if callable(args[0]):
@@ -212,16 +223,16 @@ class Session:
             kwargs.setdefault("external", "error")
 
         # Allow all external programs when running outside a sandbox.
-        if not self.virtualenv.is_sandboxed:
+        if not self.virtualenv.is_sandboxed:  # type: ignore
             kwargs["external"] = True
 
-        if args[0] in self.virtualenv.allowed_globals:
+        if args[0] in self.virtualenv.allowed_globals:  # type: ignore
             kwargs["external"] = True
 
         # Run a shell command.
         return nox.command.run(args, env=env, path=self.bin, **kwargs)
 
-    def conda_install(self, *args, **kwargs):
+    def conda_install(self, *args: str, **kwargs: Any) -> None:
         """Install invokes `conda install`_ to install packages inside of the
         session's environment.
 
@@ -268,7 +279,7 @@ class Session:
             **kwargs
         )
 
-    def install(self, *args, **kwargs):
+    def install(self, *args: str, **kwargs: Any) -> None:
         """Install invokes `pip`_ to install packages inside of the session's
         virtualenv.
 
@@ -305,7 +316,7 @@ class Session:
 
         self._run("pip", "install", *args, external="error", **kwargs)
 
-    def notify(self, target):
+    def notify(self, target: "Union[str, SessionRunner]") -> None:
         """Place the given session at the end of the queue.
 
         This method is idempotent; multiple notifications to the same session
@@ -316,81 +327,96 @@ class Session:
                 may be specified as the appropriate string (same as used for
                 ``nox -s``) or using the function object.
         """
-        self._runner.manifest.notify(target)
+        self._runner.manifest.notify(target)  # type: ignore
 
-    def log(self, *args, **kwargs):
+    def log(self, *args: Any, **kwargs: Any) -> None:
         """Outputs a log during the session."""
         logger.info(*args, **kwargs)
 
-    def error(self, *args, **kwargs):
+    def error(self, *args: Any, **kwargs: Any) -> "_typing.NoReturn":
         """Immediately aborts the session and optionally logs an error."""
-        raise _SessionQuit(*args, **kwargs)
+        raise _SessionQuit(*args, **kwargs)  # type: ignore
 
-    def skip(self, *args, **kwargs):
+    def skip(self, *args: Any, **kwargs: Any) -> "_typing.NoReturn":
         """Immediately skips the session and optionally logs a warning."""
-        raise _SessionSkip(*args, **kwargs)
+        raise _SessionSkip(*args, **kwargs)  # type: ignore
 
 
 class SessionRunner:
-    def __init__(self, name, signatures, func, global_config, manifest=None):
+    def __init__(
+        self,
+        name: str,
+        signatures: List[str],
+        func: Callable,
+        global_config: argparse.Namespace,
+        manifest: "Optional[Manifest]" = None,
+    ) -> None:
         self.name = name
         self.signatures = signatures
         self.func = func
         self.global_config = global_config
         self.manifest = manifest
-        self.venv = None
+        self.venv = None  # type: Optional[ProcessEnv]
 
     @property
-    def description(self):
+    def description(self) -> Optional[str]:
         doc = self.func.__doc__
         if doc:
             first_line = doc.strip().split("\n")[0]
             return first_line
         return None
 
-    def __str__(self):
+    def __str__(self) -> str:
         sigs = ", ".join(self.signatures)
         return "Session(name={}, signatures={})".format(self.name, sigs)
 
     @property
-    def friendly_name(self):
+    def friendly_name(self) -> str:
         return self.signatures[0] if self.signatures else self.name
 
-    def _create_venv(self):
-        if self.func.python is False:
+    def _create_venv(self) -> None:
+        if self.func.python is False:  # type: ignore
             self.venv = ProcessEnv()
             return
 
         path = _normalize_path(self.global_config.envdir, self.friendly_name)
         reuse_existing = (
-            self.func.reuse_venv or self.global_config.reuse_existing_virtualenvs
+            self.func.reuse_venv  # type: ignore
+            or self.global_config.reuse_existing_virtualenvs
         )
 
-        if not self.func.venv_backend or self.func.venv_backend == "virtualenv":
-            self.venv = VirtualEnv(
-                path, interpreter=self.func.python, reuse_existing=reuse_existing
-            )
-        elif self.func.venv_backend == "conda":
-            self.venv = CondaEnv(
-                path, interpreter=self.func.python, reuse_existing=reuse_existing
-            )
-        elif self.func.venv_backend == "venv":
+        if (
+            not self.func.venv_backend  # type: ignore
+            or self.func.venv_backend == "virtualenv"  # type: ignore
+        ):
             self.venv = VirtualEnv(
                 path,
-                interpreter=self.func.python,
+                interpreter=self.func.python,  # type: ignore
+                reuse_existing=reuse_existing,
+            )
+        elif self.func.venv_backend == "conda":  # type: ignore
+            self.venv = CondaEnv(
+                path,
+                interpreter=self.func.python,  # type: ignore
+                reuse_existing=reuse_existing,
+            )
+        elif self.func.venv_backend == "venv":  # type: ignore
+            self.venv = VirtualEnv(
+                path,
+                interpreter=self.func.python,  # type: ignore
                 reuse_existing=reuse_existing,
                 venv=True,
             )
         else:
             raise ValueError(
                 "Expected venv_backend one of ('virtualenv', 'conda', 'venv'), but got '{}'.".format(
-                    self.func.venv_backend
+                    self.func.venv_backend  # type: ignore
                 )
             )
 
-        self.venv.create()
+        self.venv.create()  # type: ignore
 
-    def execute(self):
+    def execute(self) -> "Result":
         logger.warning("Running session {}".format(self.friendly_name))
 
         try:
@@ -437,7 +463,9 @@ class SessionRunner:
 class Result:
     """An object representing the result of a session."""
 
-    def __init__(self, session, status, reason=None):
+    def __init__(
+        self, session: SessionRunner, status: Status, reason: Optional[str] = None
+    ) -> None:
         """Initialize the Result object.
 
         Args:
@@ -450,14 +478,14 @@ class Result:
         self.status = status
         self.reason = reason
 
-    def __bool__(self):
+    def __bool__(self) -> bool:
         return self.status.value > 0
 
-    def __nonzero__(self):
+    def __nonzero__(self) -> bool:
         return self.__bool__()
 
     @property
-    def imperfect(self):
+    def imperfect(self) -> str:
         """Return the English imperfect tense for the status.
 
         Returns:
@@ -471,7 +499,7 @@ class Result:
         else:
             return status
 
-    def log(self, message):
+    def log(self, message: str) -> None:
         """Log a message using the appropriate log function.
 
         Args:
@@ -486,7 +514,7 @@ class Result:
             log_function = logger.error
         log_function(message)
 
-    def serialize(self):
+    def serialize(self) -> Dict[str, Any]:
         """Return a serialized representation of this result.
 
         Returns:

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import importlib
+import importlib.machinery
 import io
 import json
 import os
+import types
 from argparse import Namespace
 from typing import List, Union
 
@@ -27,7 +28,7 @@ from nox.manifest import Manifest
 from nox.sessions import Result
 
 
-def load_nox_module(global_config):
+def load_nox_module(global_config: Namespace) -> Union[types.ModuleType, int]:
     """Load the user's noxfile and return the module object for it.
 
     .. note::
@@ -57,14 +58,16 @@ def load_nox_module(global_config):
         os.chdir(os.path.realpath(os.path.dirname(global_config.noxfile)))
         return importlib.machinery.SourceFileLoader(
             "user_nox_module", global_config.noxfile
-        ).load_module()
+        ).load_module()  # type: ignore
 
     except (IOError, OSError):
         logger.exception("Failed to load Noxfile {}".format(global_config.noxfile))
         return 2
 
 
-def merge_noxfile_options(module, global_config):
+def merge_noxfile_options(
+    module: types.ModuleType, global_config: Namespace
+) -> types.ModuleType:
     """Merges any modifications made to ``nox.options`` by the Noxfile module
     into global_config.
 
@@ -76,7 +79,7 @@ def merge_noxfile_options(module, global_config):
     return module
 
 
-def discover_manifest(module, global_config):
+def discover_manifest(module: types.ModuleType, global_config: Namespace) -> Manifest:
     """Discover all session functions in the noxfile module.
 
     Args:

--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -17,6 +17,7 @@
 import argparse
 import io
 import pkgutil
+from typing import Any, Iterator
 
 import jinja2
 import tox.config  # type: ignore
@@ -27,11 +28,11 @@ _TEMPLATE = jinja2.Template(
 )
 
 
-def wrapjoin(seq):
+def wrapjoin(seq: Iterator[Any]) -> str:
     return ", ".join(["'{}'".format(item) for item in seq])
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(description="Converts toxfiles to noxfiles.")
     parser.add_argument("--output", default="noxfile.py")
 

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -17,7 +17,7 @@ import platform
 import re
 import shutil
 import sys
-from typing import Mapping, Optional, Union
+from typing import Any, Mapping, Optional, Union
 
 import nox.command
 import py  # type: ignore
@@ -245,7 +245,7 @@ class VirtualEnv(ProcessEnv):
         interpreter: Optional[str] = None,
         reuse_existing: bool = False,
         *,
-        venv: bool = False
+        venv: bool = False,
         venv_params: Any = None
     ):
         self.location_name = location

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -17,6 +17,7 @@ import platform
 import re
 import shutil
 import sys
+from typing import Mapping, Optional, Union
 
 import nox.command
 import py  # type: ignore
@@ -31,7 +32,7 @@ _SYSTEM = platform.system()
 
 
 class InterpreterNotFound(OSError):
-    def __init__(self, interpreter):
+    def __init__(self, interpreter: str) -> None:
         super().__init__("Python interpreter {} not found".format(interpreter))
         self.interpreter = interpreter
 
@@ -45,7 +46,7 @@ class ProcessEnv:
     # Special programs that aren't included in the environment.
     allowed_globals = ()
 
-    def __init__(self, bin=None, env=None):
+    def __init__(self, bin: None = None, env: Mapping[str, str] = None) -> None:
         self._bin = bin
         self.env = os.environ.copy()
 
@@ -59,11 +60,11 @@ class ProcessEnv:
             self.env["PATH"] = os.pathsep.join([self.bin, self.env.get("PATH", "")])
 
     @property
-    def bin(self):
+    def bin(self) -> Optional[str]:
         return self._bin
 
 
-def locate_via_py(version):
+def locate_via_py(version: str) -> Optional[str]:
     """Find the Python executable using the Windows Launcher.
 
     This is based on :pep:397 which details that executing
@@ -88,9 +89,10 @@ def locate_via_py(version):
             return py_exe.sysexec("-" + version, "-c", script).strip()
         except py.process.cmdexec.Error:
             return None
+    return None
 
 
-def locate_using_path_and_version(version):
+def locate_using_path_and_version(version: str) -> Optional[str]:
     """Check the PATH's python interpreter and return it if the version
     matches.
 
@@ -123,7 +125,7 @@ def locate_using_path_and_version(version):
     return None
 
 
-def _clean_location(self):
+def _clean_location(self: "Union[CondaEnv, VirtualEnv]") -> bool:
     """Deletes any existing path-based environment"""
     if os.path.exists(self.location):
         if self.reuse_existing:
@@ -157,7 +159,12 @@ class CondaEnv(ProcessEnv):
     is_sandboxed = True
     allowed_globals = ("conda",)  # type: ignore
 
-    def __init__(self, location, interpreter=None, reuse_existing=False):
+    def __init__(
+        self,
+        location: str,
+        interpreter: Optional[str] = None,
+        reuse_existing: bool = False,
+    ):
         self.location_name = location
         self.location = os.path.abspath(location)
         self.interpreter = interpreter
@@ -167,14 +174,14 @@ class CondaEnv(ProcessEnv):
     _clean_location = _clean_location
 
     @property
-    def bin(self):
+    def bin(self) -> str:
         """Returns the location of the conda env's bin folder."""
         if _SYSTEM == "Windows":
             return os.path.join(self.location, "Scripts")
         else:
             return os.path.join(self.location, "bin")
 
-    def create(self):
+    def create(self) -> bool:
         """Create the conda env."""
         if not self._clean_location():
             logger.debug(
@@ -228,11 +235,18 @@ class VirtualEnv(ProcessEnv):
 
     is_sandboxed = True
 
-    def __init__(self, location, interpreter=None, reuse_existing=False, *, venv=False):
+    def __init__(
+        self,
+        location: str,
+        interpreter: Optional[str] = None,
+        reuse_existing: bool = False,
+        *,
+        venv: bool = False
+    ):
         self.location_name = location
         self.location = os.path.abspath(location)
         self.interpreter = interpreter
-        self._resolved = None
+        self._resolved = None  # type: Union[None, str, InterpreterNotFound]
         self.reuse_existing = reuse_existing
         self.venv_or_virtualenv = "venv" if venv else "virtualenv"
         super(VirtualEnv, self).__init__(env={"VIRTUAL_ENV": self.location})
@@ -240,7 +254,7 @@ class VirtualEnv(ProcessEnv):
     _clean_location = _clean_location
 
     @property
-    def _resolved_interpreter(self):
+    def _resolved_interpreter(self) -> str:
         """Return the interpreter, appropriately resolved for the platform.
 
         Based heavily on tox's implementation (tox/interpreters.py).
@@ -304,14 +318,14 @@ class VirtualEnv(ProcessEnv):
         raise self._resolved
 
     @property
-    def bin(self):
+    def bin(self) -> str:
         """Returns the location of the virtualenv's bin folder."""
         if _SYSTEM == "Windows":
             return os.path.join(self.location, "Scripts")
         else:
             return os.path.join(self.location, "bin")
 
-    def create(self):
+    def create(self) -> bool:
         """Create the virtualenv or venv."""
         if not self._clean_location():
             logger.debug(

--- a/nox/workflow.py
+++ b/nox/workflow.py
@@ -12,8 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import argparse
+from typing import Any, Callable, Iterable, List
 
-def execute(workflow, global_config):
+
+def execute(
+    workflow: Iterable[Callable[..., Any]], global_config: argparse.Namespace
+) -> int:
     """Execute each function in the workflow.
 
     Each function in the workflow receives the result of the previous one
@@ -38,7 +43,7 @@ def execute(workflow, global_config):
         return_value = None
         for function_ in workflow:
             # Send the previous task's return value if there was one.
-            args = []
+            args = []  # type: List[Any]
             if return_value is not None:
                 args.append(return_value)
             return_value = function_(*args, global_config=global_config)

--- a/noxfile.py
+++ b/noxfile.py
@@ -67,7 +67,7 @@ def blacken(session):
 @nox.session(python="3.8")
 def lint(session):
     session.install("flake8==3.7.8", "black==19.3b0", "mypy==0.720")
-    session.run("mypy", "nox")
+    session.run("mypy", "--disallow-untyped-defs", "nox")
     files = ["nox", "tests", "noxfile.py", "setup.py"]
     session.run("black", "--check", *files)
     session.run("flake8", "nox", *files)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -16,11 +16,6 @@ import os
 import sys
 from unittest import mock
 
-try:
-    import importlib.metadata as metadata
-except ImportError:
-    import importlib_metadata as metadata
-
 import contexter
 import nox
 import nox.__main__
@@ -28,6 +23,12 @@ import nox._options
 import nox.registry
 import nox.sessions
 import pytest
+
+try:
+    import importlib.metadata as metadata
+except ImportError:
+    import importlib_metadata as metadata
+
 
 RESOURCES = os.path.join(os.path.dirname(__file__), "resources")
 VERSION = metadata.version("nox")


### PR DESCRIPTION
# Core Changes

Since more typehints are desired, #276, I have added typehints to support the `--disallow-untyped-defs` flag. The change set is large, as I've added annotations so all functions have them. For the most part the change set only includes:

-   Add the required `typing` imports.
-   Add [function annotations](https://www.python.org/dev/peps/pep-3107/) to all functions.
-   Add and update some [type comments](https://www.python.org/dev/peps/pep-0484/#type-comments).
-   Ignore typehints, "type: ignore", which can't be solved by the above solutions.

Even though all functions have been hinted, this is by no means a complete solution. There are lots of errors being ignored, with a significant amount being around how you bind things like `python` to a `Callable`. There's also a lack of generics, and there's a lot of `Any`.

# Errors

-   When running `nox --session tests-3.6`, with 3.6.0, one of the `test_command.py` tests fails. With the final line of the original traceback being:

    ```text
    sqlite3.OperationalError: Safety level may not be changed inside a transaction
    ```
 
    This only happens when using nox. Manually changing into the venv and running pytest doesn't cause that error.

-   For me the coverage test fails. I'm unsure if this is due to not using Conda, or because I'm using x.y.0 for all Python versions.
-   The `docs` session doesn't work for me on Windows. The command `rm` can't be found.
-   Black and isort can't agree on how the imports should be formatted in `_parametrize.py`, `manifest.py` and `sessions.py`. I have manually ran Black to get the `lint` session to not error locally.

These errors are making it hard to see if anything basic is blocking the PR.

# Additional Changes

I've tried to keep the changes strictly to the core changes. However, I have deviated from that plan slightly. And so below are all the changes that I have made that are to achieve the goal, but aren't addressed above.

## Non-typehint

-   `.gitignore`

    -   Mypy creates a cache under `.mypy_cache/`.
    -   Visual Studio Code puts configurations under `.vscode/`.

-   `noxfile.py`  
    I have added the `--disallow-untyped-defs` flag when mypy is run.

## typehint

### Imports

-   `nox/manifest.py`  
    Import `argparse` and `nox.sessions.Session`.
    
-   `nox/sessions.py`  
    Import `argparse` and `nox.manifest.Manifest`.

-   `nox/tasks.py`  
    Import `importlib.machiniery` and `types`.

-   `nox/workflow.py`  
    Import `argparse`.

### [Type Aliases](https://www.python.org/dev/peps/pep-0484/#type-aliases)

These are to reduce duplicate definitons, and to make the types easier to read.

-   `nox/_parameterize.py`  
    Add `ArgValue`.

-   `nox/registry.py`  
    Add `Python`.

### Other

-   `nox/logger.py`  
    Use `typing.cast` to ensure `logger` gets the correct type.

-   `nox/virtualenv.py`  
    Add an explicit `return None` to `locate_via_py`.

    The added return can be replaced with `--no-warn-no-return` flag to mypy instead.

-   `nox/_typing.py`  
    I have added this file as a small central interface to `typing` and `typing_extensions`. This is as `typing_extensions` supplies the backport and experimental typing features. Currently it, `_typing.py`, only contains code to interface with Python 3.5.0-3 and Python 3.6.0-1.

    I have used `__all__` to ignore flake8 as `NoReturn` is being used, but is being used in a string annotation - as it will not be defined in Python 3.5.0 if the user doesn't have `typing_extensions` installed.

---

This is a fairly big PR. I'm happy to split it up if desired.
