### PR TITLE
Convert function decorators to class decorators

### DIFF
--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -62,7 +62,7 @@ class Func(FunctionDecorator):
 
 
 class Call(FunctionDecorator):
-    def __init__(self, func: Callable[..., Any], param_spec: "Param") -> None:
+    def __init__(self, func: Func, param_spec: "Param") -> None:
         self._func = func
         self.param_spec = param_spec
         self.session_signature = "({})".format(param_spec)
@@ -72,7 +72,5 @@ class Call(FunctionDecorator):
         return self._func(*args, **kwargs)
 
     @classmethod
-    def generate_calls(
-        cls, func: Callable[..., Any], param_specs: "Iterable[Param]"
-    ) -> "List[Call]":
+    def generate_calls(cls, func: Func, param_specs: "Iterable[Param]") -> "List[Call]":
         return [cls(func, param_spec) for param_spec in param_specs]

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -61,15 +61,22 @@ class Func(FunctionDecorator):
         )
 
 
-class Call(FunctionDecorator):
+class Call(Func):
     def __init__(self, func: Func, param_spec: "Param") -> None:
-        self._func = func
+        super().__init__(
+            func,
+            func.python,
+            func.reuse_venv,
+            None,
+            func.venv_backend,
+            func.venv_params,
+        )
         self.param_spec = param_spec
         self.session_signature = "({})".format(param_spec)
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         kwargs.update(self.param_spec.call_spec)
-        return self._func(*args, **kwargs)
+        return super().__call__(*args, **kwargs)
 
     @classmethod
     def generate_calls(cls, func: Func, param_specs: "Iterable[Param]") -> "List[Call]":

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -1,5 +1,12 @@
+import copy
 import functools
-from typing import Any, Callable, cast
+import types
+from typing import Any, Callable, Iterable, List, Optional, cast
+
+from ._typing import TYPE_CHECKING, Python
+
+if TYPE_CHECKING:
+    from ._parametrize import Param
 
 
 class FunctionDecorator:
@@ -8,3 +15,64 @@ class FunctionDecorator:
     ) -> "FunctionDecorator":
         obj = super().__new__(cls)
         return cast("FunctionDecorator", functools.wraps(func)(obj))
+
+
+def _copy_func(src: Callable, name: str = None) -> Callable:
+    dst = types.FunctionType(
+        src.__code__,
+        src.__globals__,  # type: ignore
+        name=name or src.__name__,
+        argdefs=src.__defaults__,  # type: ignore
+        closure=src.__closure__,  # type: ignore
+    )
+    dst.__dict__.update(copy.deepcopy(src.__dict__))
+    dst = functools.update_wrapper(dst, src)  # type: ignore
+    dst.__kwdefaults__ = src.__kwdefaults__  # type: ignore
+    return dst
+
+
+class Func(FunctionDecorator):
+    def __init__(
+        self,
+        func: Callable,
+        python: Python = None,
+        reuse_venv: Optional[bool] = None,
+        name: Optional[str] = None,
+        venv_backend: Any = None,
+        venv_params: Any = None,
+    ):
+        self.func = func
+        self.python = python
+        self.reuse_venv = reuse_venv
+        self.venv_backend = venv_backend
+        self.venv_params = venv_params
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        return self.func(*args, **kwargs)
+
+    def copy(self, name: str = None) -> "Func":
+        return Func(
+            _copy_func(self.func, name),
+            self.python,
+            self.reuse_venv,
+            name,
+            self.venv_backend,
+            self.venv_params,
+        )
+
+
+class Call(FunctionDecorator):
+    def __init__(self, func: Callable[..., Any], param_spec: "Param") -> None:
+        self._func = func
+        self.param_spec = param_spec
+        self.session_signature = "({})".format(param_spec)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        kwargs.update(self.param_spec.call_spec)
+        return self._func(*args, **kwargs)
+
+    @classmethod
+    def generate_calls(
+        cls, func: Callable[..., Any], param_specs: "Iterable[Param]"
+    ) -> "List[Call]":
+        return [cls(func, param_spec) for param_spec in param_specs]

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -1,0 +1,10 @@
+import functools
+from typing import Any, Callable, cast
+
+
+class FunctionDecorator:
+    def __new__(
+        cls, func: Callable[..., Any], *args: Any, **kwargs: Any
+    ) -> "FunctionDecorator":
+        obj = super().__new__(cls)
+        return cast("FunctionDecorator", functools.wraps(func)(obj))

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -3,9 +3,9 @@ import functools
 import types
 from typing import Any, Callable, Iterable, List, Optional, cast
 
-from ._typing import TYPE_CHECKING, Python
+from . import _typing
 
-if TYPE_CHECKING:
+if _typing.TYPE_CHECKING:
     from ._parametrize import Param
 
 
@@ -35,7 +35,7 @@ class Func(FunctionDecorator):
     def __init__(
         self,
         func: Callable,
-        python: Python = None,
+        python: _typing.Python = None,
         reuse_venv: Optional[bool] = None,
         name: Optional[str] = None,
         venv_backend: Any = None,

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -16,8 +16,6 @@ import functools
 import itertools
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
 
-from . import _decorators
-
 
 class Param:
     """A class that encapsulates a single set of parameters to a parametrized
@@ -169,20 +167,3 @@ def update_param_specs(
             spec.update(new_spec)
             combined_specs.append(spec)
     return combined_specs
-
-
-class Call(_decorators.FunctionDecorator):
-    def __init__(self, func: Callable[..., Any], param_spec: Param) -> None:
-        self._func = func
-        self.param_spec = param_spec
-        self.session_signature = "({})".format(param_spec)
-
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        kwargs.update(self.param_spec.call_spec)
-        return self._func(*args, **kwargs)
-
-    @classmethod
-    def generate_calls(
-        cls, func: Callable[..., Any], param_specs: Iterable[Param]
-    ) -> "List[Call]":
-        return [cls(func, param_spec) for param_spec in param_specs]

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -14,18 +14,9 @@
 
 import functools
 import itertools
-from typing import (
-    Any,
-    Callable,
-    Dict,
-    Iterable,
-    List,
-    Optional,
-    Sequence,
-    Tuple,
-    Union,
-    cast,
-)
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Tuple, Union
+
+from . import _decorators
 
 
 class Param:
@@ -180,12 +171,7 @@ def update_param_specs(
     return combined_specs
 
 
-class Call:
-    def __new__(cls, func: Callable[..., Any], param_spec: Param) -> "Call":
-        obj = super().__new__(cls)
-        obj.__init__(func, param_spec)
-        return cast("Call", functools.wraps(func)(obj))
-
+class Call(_decorators.FunctionDecorator):
     def __init__(self, func: Callable[..., Any], param_spec: Param) -> None:
         self._func = func
         self.param_spec = param_spec

--- a/nox/_typing.py
+++ b/nox/_typing.py
@@ -1,4 +1,6 @@
-__all__ = ["TYPE_CHECKING", "NoReturn"]
+__all__ = ["TYPE_CHECKING", "NoReturn", "Python"]
+
+import typing as _typing
 
 try:
     from typing import TYPE_CHECKING
@@ -15,3 +17,5 @@ except ImportError:
         from typing_extensions import NoReturn
     except ImportError:
         pass
+
+Python = _typing.Optional[_typing.Union[str, _typing.Sequence[str], bool]]

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -196,11 +196,7 @@ class Manifest:
                 # Ensure that specifying session-python will run all parameterizations.
                 long_names.append("{}-{}".format(name, func.python))
 
-            sessions.append(
-                SessionRunner(
-                    name, long_names, call, self._config, self
-                )  # type: ignore
-            )
+            sessions.append(SessionRunner(name, long_names, call, self._config, self))
 
         # Edge case: If the parameters made it such that there were no valid
         # calls, add an empty, do-nothing session.

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -183,8 +183,8 @@ class Manifest:
         if isinstance(func.python, (list, tuple, set)):  # type: ignore
 
             for python in func.python:  # type: ignore
-                single_func = _copy_func(func)
-                single_func.python = python  # type: ignore
+                single_func = func.copy()  # type: ignore
+                single_func.python = python
                 session = self.make_session(name, single_func, multi=True)
                 sessions.extend(session)
 

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -13,28 +13,11 @@
 # limitations under the License.
 
 import argparse
-import copy
-import functools
 import itertools
-import types
 from typing import Any, Callable, Iterable, Iterator, List, Mapping, Set, Tuple, Union
 
-from nox._parametrize import Call
+from nox._decorators import Call
 from nox.sessions import Session, SessionRunner
-
-
-def _copy_func(src: Callable, name: str = None) -> Callable:
-    dst = types.FunctionType(
-        src.__code__,
-        src.__globals__,  # type: ignore
-        name=name or src.__name__,
-        argdefs=src.__defaults__,  # type: ignore
-        closure=src.__closure__,  # type: ignore
-    )
-    dst.__dict__.update(copy.deepcopy(src.__dict__))
-    dst = functools.update_wrapper(dst, src)  # type: ignore
-    dst.__kwdefaults__ = src.__kwdefaults__  # type: ignore
-    return dst
 
 
 class Manifest:

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -19,7 +19,7 @@ import itertools
 import types
 from typing import Any, Callable, Iterable, Iterator, List, Mapping, Set, Tuple, Union
 
-from nox._parametrize import generate_calls
+from nox._parametrize import Call
 from nox.sessions import Session, SessionRunner
 
 
@@ -27,7 +27,7 @@ def _copy_func(src: Callable, name: str = None) -> Callable:
     dst = types.FunctionType(
         src.__code__,
         src.__globals__,  # type: ignore
-        name=name or src.__name__,  # type: ignore
+        name=name or src.__name__,
         argdefs=src.__defaults__,  # type: ignore
         closure=src.__closure__,  # type: ignore
     )
@@ -206,13 +206,11 @@ class Manifest:
 
         # Since this function is parametrized, we need to add a distinct
         # session for each permutation.
-        calls = generate_calls(func, func.parametrize)  # type: ignore
+        calls = Call.generate_calls(func, func.parametrize)  # type: ignore
         for call in calls:
             long_names = []
             if not multi:
-                long_names.append(
-                    "{}{}".format(name, call.session_signature)  # type: ignore
-                )
+                long_names.append("{}{}".format(name, call.session_signature))
             if func.python:  # type: ignore
                 long_names.append(
                     "{}-{}{}".format(

--- a/nox/registry.py
+++ b/nox/registry.py
@@ -15,42 +15,12 @@
 import collections
 import copy
 import functools
-from typing import Any, Callable, Optional, Sequence, Union
+from typing import Any, Callable, Optional
 
-from . import _decorators, manifest
+from ._decorators import Func
+from ._typing import Python
 
 _REGISTRY = collections.OrderedDict()  # type: collections.OrderedDict[str, Func]
-Python = Optional[Union[str, Sequence[str], bool]]
-
-
-class Func(_decorators.FunctionDecorator):
-    def __init__(
-        self,
-        func: Callable,
-        python: Python = None,
-        reuse_venv: Optional[bool] = None,
-        name: Optional[str] = None,
-        venv_backend: Any = None,
-        venv_params: Any = None,
-    ):
-        self.func = func
-        self.python = python
-        self.reuse_venv = reuse_venv
-        self.venv_backend = venv_backend
-        self.venv_params = venv_params
-
-    def __call__(self, *args: Any, **kwargs: Any) -> Any:
-        return self.func(*args, **kwargs)
-
-    def copy(self, name: str = None) -> "Func":
-        return Func(
-            manifest._copy_func(self.func, name),
-            self.python,
-            self.reuse_venv,
-            name,
-            self.venv_backend,
-            self.venv_params,
-        )
 
 
 def session_decorator(

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -34,6 +34,7 @@ from typing import (
 import nox.command
 import py  # type: ignore
 from nox import _typing
+from nox._decorators import Func
 from nox.logger import logger
 from nox.virtualenv import CondaEnv, ProcessEnv, VirtualEnv
 
@@ -124,7 +125,7 @@ class Session:
     @property
     def python(self) -> Optional[Union[str, Sequence[str], bool]]:
         """The python version passed into ``@nox.session``."""
-        return self._runner.func.python  # type: ignore
+        return self._runner.func.python
 
     @property
     def bin(self) -> str:
@@ -356,7 +357,7 @@ class SessionRunner:
         self,
         name: str,
         signatures: List[str],
-        func: Callable,
+        func: Func,
         global_config: argparse.Namespace,
         manifest: "Optional[Manifest]" = None,
     ) -> None:
@@ -384,45 +385,41 @@ class SessionRunner:
         return self.signatures[0] if self.signatures else self.name
 
     def _create_venv(self) -> None:
-        if self.func.python is False:  # type: ignore
+        if self.func.python is False:
             self.venv = ProcessEnv()
             return
 
         path = _normalize_path(self.global_config.envdir, self.friendly_name)
         reuse_existing = (
-            self.func.reuse_venv  # type: ignore
-            or self.global_config.reuse_existing_virtualenvs
+            self.func.reuse_venv or self.global_config.reuse_existing_virtualenvs
         )
 
-        if (
-            not self.func.venv_backend  # type: ignore
-            or self.func.venv_backend == "virtualenv"  # type: ignore
-        ):
+        if not self.func.venv_backend or self.func.venv_backend == "virtualenv":
             self.venv = VirtualEnv(
                 path,
                 interpreter=self.func.python,  # type: ignore
                 reuse_existing=reuse_existing,
-                venv_params=self.func.venv_params,  # type: ignore
+                venv_params=self.func.venv_params,
             )
-        elif self.func.venv_backend == "conda":  # type: ignore
+        elif self.func.venv_backend == "conda":
             self.venv = CondaEnv(
                 path,
                 interpreter=self.func.python,  # type: ignore
                 reuse_existing=reuse_existing,
-                venv_params=self.func.venv_params,  # type: ignore
+                venv_params=self.func.venv_params,
             )
-        elif self.func.venv_backend == "venv":  # type: ignore
+        elif self.func.venv_backend == "venv":
             self.venv = VirtualEnv(
                 path,
                 interpreter=self.func.python,  # type: ignore
                 reuse_existing=reuse_existing,
                 venv=True,
-                venv_params=self.func.venv_params,  # type: ignore
+                venv_params=self.func.venv_params,
             )
         else:
             raise ValueError(
                 "Expected venv_backend one of ('virtualenv', 'conda', 'venv'), but got '{}'.".format(
-                    self.func.venv_backend  # type: ignore
+                    self.func.venv_backend
                 )
             )
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -67,7 +67,7 @@ def blacken(session):
 @nox.session(python="3.8")
 def lint(session):
     session.install("flake8==3.7.8", "black==19.3b0", "mypy==0.720")
-    session.run("mypy", "--disallow-untyped-defs", "nox")
+    session.run("mypy", "--disallow-untyped-defs", "--warn-unused-ignores", "nox")
     files = ["nox", "tests", "noxfile.py", "setup.py"]
     session.run("black", "--check", *files)
     session.run("flake8", "nox", *files)

--- a/tests/test__parametrize.py
+++ b/tests/test__parametrize.py
@@ -166,7 +166,7 @@ def test_generate_calls_simple():
         _parametrize.Param(3, arg_names=arg_names),
     ]
 
-    calls = _parametrize.generate_calls(f, call_specs)
+    calls = _parametrize.Call.generate_calls(f, call_specs)
 
     assert len(calls) == 3
     assert calls[0].session_signature == "(abc=1)"
@@ -198,7 +198,7 @@ def test_generate_calls_multiple_args():
         _parametrize.Param(3, "c", arg_names=arg_names),
     ]
 
-    calls = _parametrize.generate_calls(f, call_specs)
+    calls = _parametrize.Call.generate_calls(f, call_specs)
 
     assert len(calls) == 3
     assert calls[0].session_signature == "(abc=1, foo='a')"
@@ -223,7 +223,7 @@ def test_generate_calls_ids():
         _parametrize.Param(2, arg_names=arg_names, id="b"),
     ]
 
-    calls = _parametrize.generate_calls(f, call_specs)
+    calls = _parametrize.Call.generate_calls(f, call_specs)
 
     assert len(calls) == 2
     assert calls[0].session_signature == "(a)"

--- a/tests/test__parametrize.py
+++ b/tests/test__parametrize.py
@@ -15,7 +15,7 @@
 from unittest import mock
 
 import pytest
-from nox import _parametrize
+from nox import _decorators, _parametrize
 
 
 @pytest.mark.parametrize(
@@ -166,7 +166,7 @@ def test_generate_calls_simple():
         _parametrize.Param(3, arg_names=arg_names),
     ]
 
-    calls = _parametrize.Call.generate_calls(f, call_specs)
+    calls = _decorators.Call.generate_calls(f, call_specs)
 
     assert len(calls) == 3
     assert calls[0].session_signature == "(abc=1)"
@@ -198,7 +198,7 @@ def test_generate_calls_multiple_args():
         _parametrize.Param(3, "c", arg_names=arg_names),
     ]
 
-    calls = _parametrize.Call.generate_calls(f, call_specs)
+    calls = _decorators.Call.generate_calls(f, call_specs)
 
     assert len(calls) == 3
     assert calls[0].session_signature == "(abc=1, foo='a')"
@@ -223,7 +223,7 @@ def test_generate_calls_ids():
         _parametrize.Param(2, arg_names=arg_names, id="b"),
     ]
 
-    calls = _parametrize.Call.generate_calls(f, call_specs)
+    calls = _decorators.Call.generate_calls(f, call_specs)
 
     assert len(calls) == 2
     assert calls[0].session_signature == "(a)"

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -17,8 +17,8 @@ from unittest import mock
 
 import nox
 import pytest
+from nox._decorators import Func
 from nox.manifest import Manifest, _null_session_func
-from nox.registry import Func
 
 
 def create_mock_sessions():

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -18,6 +18,7 @@ from unittest import mock
 import nox
 import pytest
 from nox.manifest import Manifest, _null_session_func
+from nox.registry import Func
 
 
 def create_mock_sessions():
@@ -173,9 +174,8 @@ def test_add_session_multiple_pythons():
     def session_func():
         pass
 
-    session_func.python = ["3.5", "3.6"]
-
-    for session in manifest.make_session("my_session", session_func):
+    func = Func(session_func, python=["3.5", "3.6"])
+    for session in manifest.make_session("my_session", func):
         manifest.add_session(session)
 
     assert len(manifest) == 2
@@ -205,10 +205,10 @@ def test_add_session_parametrized_multiple_pythons():
     def my_session(session, param):
         pass
 
-    my_session.python = ["2.7", "3.6"]
+    func = Func(my_session, python=["2.7", "3.6"])
 
     # Add the session to the manifest.
-    for session in manifest.make_session("my_session", my_session):
+    for session in manifest.make_session("my_session", func):
         manifest.add_session(session)
     assert len(manifest) == 4
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -189,10 +189,10 @@ def test_add_session_parametrized():
     def my_session(session, param):
         pass
 
-    my_session.python = None
+    func = Func(my_session, python=None)
 
     # Add the session to the manifest.
-    for session in manifest.make_session("my_session", my_session):
+    for session in manifest.make_session("my_session", func):
         manifest.add_session(session)
     assert len(manifest) == 3
 


### PR DESCRIPTION
Hey, sorry for the delay.  
I have improved typing as discussed in #287. I have:

-   Updated the `noxfile.py` to include the `--warn-unused-ignores` flag.
-   Made a `_decorators` file, as the code started to call and inherit from multiple different files. This was causing some cyclical dependencies.
-   Changed [`_parametrize.generate_calls`](https://github.com/theacodes/nox/blob/1bd08bc7d85f7276b07a72b720c673a5df384188/nox/_parametrize.py#L172) to a class decorator, `Call`.
-   Changed [`registry.session_decorator`](https://github.com/theacodes/nox/blob/1bd08bc7d85f7276b07a72b720c673a5df384188/nox/registry.py#L24) to delegate to a class decorator, `Func`.
-   Moved [`manifest._copy_func`](https://github.com/theacodes/nox/blob/1bd08bc7d85f7276b07a72b720c673a5df384188/nox/manifest.py#L26) into `_decorators` and call it in `Func`.
-   Changed [`manifest.Manifest.make_session`](https://github.com/theacodes/nox/blob/1bd08bc7d85f7276b07a72b720c673a5df384188/nox/manifest.py#L186) to use `Func.copy` rather than `manifest._copy_func`.
-   Made `Call` subclass `Func`.
-   Removed a large amount of `# type: ignore`.
-   Updated a few `Callable` to `Func`.
-   Updated tests.

Given the size of the existing PR I have decided to leave the typing of the attributes as is.
