### PR TITLE
Stop building universal wheels

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 1


### PR DESCRIPTION
### References
As described in  #291, Nox ist still building universal wheels and publishing them to PyPI with the `py2.py3` identifier in the wheel's file name.

### What was changed
* Remove setup.cfg outright (the `bdist_wheel` setting of `universal = 1` was the only thing it contained)

### Effects/tests
Tested as follows:
```console
$ python setup.py sdist bdist_wheel  # wheel name is now marked as py3 instead of py2.py3
$ pip install dist/nox-2019.11.9-py3-none-any.whl
$ nox  # sucessfully runs it own tests
$ uninstall nox
$ pip install dist/nox-2019.11.9.tar.gz  # just to be safe
$ nox  # also still works, phew ;)