### PR TITLE
Don't run coverage on 3.6.0

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -78,7 +78,13 @@ def blacken(session):
 @nox.session(python="3.8")
 def lint(session):
     session.install("flake8==3.7.8", "black==19.3b0", "mypy==0.720")
-    session.run("mypy", "--disallow-untyped-defs", "--warn-unused-ignores", "nox")
+    session.run(
+        "mypy",
+        "--disallow-untyped-defs",
+        "--warn-unused-ignores",
+        "--ignore-missing-imports",
+        "nox",
+    )
     files = ["nox", "tests", "noxfile.py", "setup.py"]
     session.run("black", "--check", *files)
     session.run("flake8", "nox", *files)


### PR DESCRIPTION
Fixes #295 - due to a bug in Python 3.6.0 coverage fails to run successfully.