### PR TITLE
Fixed the default paths for conda on windows where the `python.exe` found was not the correct one

### DIFF
--- a/nox/command.py
+++ b/nox/command.py
@@ -14,7 +14,7 @@
 
 import os
 import sys
-from typing import Any, Iterable, Optional, Sequence, Union
+from typing import Any, Iterable, Optional, Sequence, Union, List
 
 import py
 from nox.logger import logger
@@ -29,12 +29,12 @@ class CommandFailed(Exception):
         self.reason = reason
 
 
-def which(program: str, path: Optional[str]) -> str:
+def which(program: str, paths: Optional[List[str]]) -> str:
     """Finds the full path to an executable."""
     full_path = None
 
-    if path:
-        full_path = py.path.local.sysfind(program, paths=[path])
+    if paths:
+        full_path = py.path.local.sysfind(program, paths=paths)
 
     if full_path:
         return full_path.strpath
@@ -66,7 +66,7 @@ def run(
     *,
     env: Optional[dict] = None,
     silent: bool = False,
-    path: Optional[str] = None,
+    paths: Optional[List[str]] = None,
     success_codes: Optional[Iterable[int]] = None,
     log: bool = True,
     external: bool = False,
@@ -80,12 +80,12 @@ def run(
     cmd, args = args[0], args[1:]
     full_cmd = "{} {}".format(cmd, " ".join(args))
 
-    cmd_path = which(cmd, path)
+    cmd_path = which(cmd, paths)
 
     if log:
         logger.info(full_cmd)
 
-        is_external_tool = path is not None and not cmd_path.startswith(path)
+        is_external_tool = paths is not None and not any(cmd_path.startswith(path) for path in paths)
         if is_external_tool:
             if external == "error":
                 logger.error(

--- a/nox/command.py
+++ b/nox/command.py
@@ -85,7 +85,9 @@ def run(
     if log:
         logger.info(full_cmd)
 
-        is_external_tool = paths is not None and not any(cmd_path.startswith(path) for path in paths)
+        is_external_tool = paths is not None and not any(
+            cmd_path.startswith(path) for path in paths
+        )
         if is_external_tool:
             if external == "error":
                 logger.error(

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -131,9 +131,9 @@ class Session:
         return self._runner.func.python
 
     @property
-    def bin(self) -> Optional[str]:
-        """The bin directory for the virtualenv."""
-        return self.virtualenv.bin
+    def bin_paths(self) -> Optional[List[str]]:
+        """The bin directories for the virtualenv."""
+        return self.virtualenv.bin_paths
 
     @property
     def interactive(self) -> bool:
@@ -243,7 +243,7 @@ class Session:
             kwargs["external"] = True
 
         # Run a shell command.
-        return nox.command.run(args, env=env, path=self.bin, **kwargs)
+        return nox.command.run(args, env=env, paths=self.bin_paths, **kwargs)
 
     def conda_install(self, *args: str, **kwargs: Any) -> None:
         """Install invokes `conda install`_ to install packages inside of the

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -139,10 +139,8 @@ class Session:
     @property
     def bin(self) -> Optional[str]:
         """The first bin directory for the virtualenv."""
-        try:
-            return self.bin_paths[0]
-        except (TypeError, KeyError):
-            return None
+        paths = self.bin_paths
+        return paths[0] if paths is not None else None
 
     def create_tmp(self) -> str:
         """Create, and return, a temporary directory."""

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -136,6 +136,14 @@ class Session:
         """The bin directories for the virtualenv."""
         return self.virtualenv.bin_paths
 
+    @property
+    def bin(self) -> Optional[str]:
+        """The first bin directory for the virtualenv."""
+        try:
+            return self.bin_paths[0]
+        except (TypeError, KeyError):
+            return None
+
     def create_tmp(self) -> str:
         """Create, and return, a temporary directory."""
         tmpdir = os.path.join(self._runner.envdir, "tmp")

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -67,6 +67,12 @@ class ProcessEnv:
     def bin_paths(self) -> Optional[List[str]]:
         return self._bin_paths
 
+    @property
+    def bin(self) -> Optional[str]:
+        """The first bin directory for the virtualenv."""
+        paths = self.bin_paths
+        return paths[0] if paths is not None else None
+
     def create(self) -> bool:
         raise NotImplementedError("ProcessEnv.create should be overwritten in subclass")
 

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -59,7 +59,9 @@ class ProcessEnv:
             self.env.pop(key, None)
 
         if self.bin_paths:
-            self.env["PATH"] = os.pathsep.join(self.bin_paths + [self.env.get("PATH", "")])
+            self.env["PATH"] = os.pathsep.join(
+                self.bin_paths + [self.env.get("PATH", "")]
+            )
 
     @property
     def bin_paths(self) -> Optional[List[str]]:

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -122,7 +122,7 @@ def test_run_path_nonexistent():
     result = nox.command.run(
         [PYTHON, "-c", "import sys; print(sys.executable)"],
         silent=True,
-        path="/non/existent",
+        paths=["/non/existent"],
     )
 
     assert "/non/existent" not in result
@@ -135,14 +135,14 @@ def test_run_path_existent(tmpdir, monkeypatch):
 
     with mock.patch("nox.command.popen") as mock_command:
         mock_command.return_value = (0, "")
-        nox.command.run(["testexc"], silent=True, path=tmpdir.strpath)
+        nox.command.run(["testexc"], silent=True, paths=[tmpdir.strpath])
         mock_command.assert_called_with([executable.strpath], env=None, silent=True)
 
 
 def test_run_external_warns(tmpdir, caplog):
     caplog.set_level(logging.WARNING)
 
-    nox.command.run([PYTHON, "--version"], silent=True, path=tmpdir.strpath)
+    nox.command.run([PYTHON, "--version"], silent=True, paths=[tmpdir.strpath])
 
     assert "external=True" in caplog.text
 
@@ -151,7 +151,7 @@ def test_run_external_silences(tmpdir, caplog):
     caplog.set_level(logging.WARNING)
 
     nox.command.run(
-        [PYTHON, "--version"], silent=True, path=tmpdir.strpath, external=True
+        [PYTHON, "--version"], silent=True, paths=[tmpdir.strpath], external=True
     )
 
     assert "external=True" not in caplog.text
@@ -162,7 +162,7 @@ def test_run_external_raises(tmpdir, caplog):
 
     with pytest.raises(nox.command.CommandFailed):
         nox.command.run(
-            [PYTHON, "--version"], silent=True, path=tmpdir.strpath, external="error"
+            [PYTHON, "--version"], silent=True, paths=[tmpdir.strpath], external="error"
         )
 
     assert "external=True" in caplog.text

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -221,7 +221,10 @@ class TestSession:
             session.run("conda", "--version")
 
         run.assert_called_once_with(
-            ("conda", "--version"), external=True, env=mock.ANY, paths=["/path/to/env/bin"]
+            ("conda", "--version"),
+            external=True,
+            env=mock.ANY,
+            paths=["/path/to/env/bin"],
         )
 
     def test_run_external_with_error_on_external_run(self):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -101,7 +101,15 @@ class TestSession:
         assert session.posargs is runner.global_config.posargs
         assert session.virtualenv is runner.venv
         assert session.bin_paths is runner.venv.bin_paths
+        assert session.bin is runner.venv.bin_paths[0]
         assert session.python is runner.func.python
+
+    def test_no_bin_paths(self):
+        session, runner = self.make_session_and_runner()
+
+        runner.venv.bin_paths = None
+        assert session.bin is None
+        assert session.bin_paths is None
 
     def test_virtualenv_as_none(self):
         session, runner = self.make_session_and_runner()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -71,7 +71,7 @@ class TestSession:
         )
         runner.venv = mock.create_autospec(nox.virtualenv.VirtualEnv)
         runner.venv.env = {}
-        runner.venv.bin = "/no/bin/for/you"
+        runner.venv.bin_paths = ["/no/bin/for/you"]
         return nox.sessions.Session(runner=runner), runner
 
     def test_properties(self):
@@ -80,7 +80,7 @@ class TestSession:
         assert session.env is runner.venv.env
         assert session.posargs is runner.global_config.posargs
         assert session.virtualenv is runner.venv
-        assert session.bin is runner.venv.bin
+        assert session.bin_paths is runner.venv.bin_paths
         assert session.python is runner.func.python
 
     def test_virtualenv_as_none(self):
@@ -167,7 +167,7 @@ class TestSession:
             ("pip", "install", "spam"),
             env=mock.ANY,
             external=mock.ANY,
-            path=mock.ANY,
+            paths=mock.ANY,
             silent=mock.ANY,
         )
 
@@ -205,7 +205,7 @@ class TestSession:
             session.run(sys.executable, "--version")
 
         run.assert_called_once_with(
-            (sys.executable, "--version"), external=True, env=mock.ANY, path=None
+            (sys.executable, "--version"), external=True, env=mock.ANY, paths=None
         )
 
     def test_run_external_condaenv(self):
@@ -214,14 +214,14 @@ class TestSession:
         runner.venv = mock.create_autospec(nox.virtualenv.CondaEnv)
         runner.venv.allowed_globals = ("conda",)
         runner.venv.env = {}
-        runner.venv.bin = "/path/to/env/bin"
+        runner.venv.bin_paths = ["/path/to/env/bin"]
         runner.venv.create.return_value = True
 
         with mock.patch("nox.command.run", autospec=True) as run:
             session.run("conda", "--version")
 
         run.assert_called_once_with(
-            ("conda", "--version"), external=True, env=mock.ANY, path="/path/to/env/bin"
+            ("conda", "--version"), external=True, env=mock.ANY, paths=["/path/to/env/bin"]
         )
 
     def test_run_external_with_error_on_external_run(self):
@@ -236,7 +236,7 @@ class TestSession:
         session, runner = self.make_session_and_runner()
         runner.venv = mock.create_autospec(nox.virtualenv.CondaEnv)
         runner.venv.env = {}
-        runner.venv.bin = "/path/to/env/bin"
+        runner.venv.bin_paths = ["/path/to/env/bin"]
 
         runner.global_config.error_on_external_run = True
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -186,8 +186,7 @@ def test_condaenv_create_interpreter(make_conda):
 @mock.patch("nox.virtualenv._SYSTEM", new="Windows")
 def test_condaenv_bin_windows(make_conda):
     venv, dir_ = make_conda()
-    assert len(venv.bin_paths) == 1
-    assert dir_.join("Scripts").strpath == venv.bin_paths[0]
+    assert [dir_.strpath, dir_.join("Scripts").strpath] == venv.bin_paths
 
 
 def test_constructor_defaults(make_one):

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -120,7 +120,7 @@ def patch_sysfind(make_mocked_interpreter_path):
 
 def test_process_env_constructor():
     penv = nox.virtualenv.ProcessEnv()
-    assert not penv.bin
+    assert not penv.bin_paths
 
     penv = nox.virtualenv.ProcessEnv(env={"SIGIL": "123"})
     assert penv.env["SIGIL"] == "123"
@@ -186,7 +186,8 @@ def test_condaenv_create_interpreter(make_conda):
 @mock.patch("nox.virtualenv._SYSTEM", new="Windows")
 def test_condaenv_bin_windows(make_conda):
     venv, dir_ = make_conda()
-    assert dir_.join("Scripts").strpath == venv.bin
+    assert len(venv.bin_paths) == 1
+    assert dir_.join("Scripts").strpath == venv.bin_paths[0]
 
 
 def test_constructor_defaults(make_one):
@@ -209,14 +210,16 @@ def test_env(monkeypatch, make_one):
     monkeypatch.setenv("SIGIL", "123")
     venv, _ = make_one()
     assert venv.env["SIGIL"] == "123"
-    assert venv.bin in venv.env["PATH"]
-    assert venv.bin not in os.environ["PATH"]
+    assert len(venv.bin_paths) == 1
+    assert venv.bin_paths[0] in venv.env["PATH"]
+    assert venv.bin_paths[0] not in os.environ["PATH"]
 
 
 def test_blacklisted_env(monkeypatch, make_one):
     monkeypatch.setenv("__PYVENV_LAUNCHER__", "meep")
     venv, _ = make_one()
-    assert "__PYVENV_LAUNCHER__" not in venv.bin
+    assert len(venv.bin_paths) == 1
+    assert "__PYVENV_LAUNCHER__" not in venv.bin_paths[0]
 
 
 def test__clean_location(monkeypatch, make_one):
@@ -249,19 +252,21 @@ def test__clean_location(monkeypatch, make_one):
     assert venv._clean_location()
 
 
-def test_bin(make_one):
+def test_bin_paths(make_one):
     venv, dir_ = make_one()
 
+    assert len(venv.bin_paths) == 1
     if IS_WINDOWS:
-        assert dir_.join("Scripts").strpath == venv.bin
+        assert dir_.join("Scripts").strpath == venv.bin_paths[0]
     else:
-        assert dir_.join("bin").strpath == venv.bin
+        assert dir_.join("bin").strpath == venv.bin_paths[0]
 
 
 @mock.patch("nox.virtualenv._SYSTEM", new="Windows")
 def test_bin_windows(make_one):
     venv, dir_ = make_one()
-    assert dir_.join("Scripts").strpath == venv.bin
+    assert len(venv.bin_paths) == 1
+    assert dir_.join("Scripts").strpath == venv.bin_paths[0]
 
 
 def test_create(make_one):

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -218,7 +218,8 @@ def test_blacklisted_env(monkeypatch, make_one):
     monkeypatch.setenv("__PYVENV_LAUNCHER__", "meep")
     venv, _ = make_one()
     assert len(venv.bin_paths) == 1
-    assert "__PYVENV_LAUNCHER__" not in venv.bin_paths[0]
+    assert venv.bin_paths[0] == venv.bin
+    assert "__PYVENV_LAUNCHER__" not in venv.bin
 
 
 def test__clean_location(monkeypatch, make_one):
@@ -255,17 +256,20 @@ def test_bin_paths(make_one):
     venv, dir_ = make_one()
 
     assert len(venv.bin_paths) == 1
+    assert venv.bin_paths[0] == venv.bin
+
     if IS_WINDOWS:
-        assert dir_.join("Scripts").strpath == venv.bin_paths[0]
+        assert dir_.join("Scripts").strpath == venv.bin
     else:
-        assert dir_.join("bin").strpath == venv.bin_paths[0]
+        assert dir_.join("bin").strpath == venv.bin
 
 
 @mock.patch("nox.virtualenv._SYSTEM", new="Windows")
 def test_bin_windows(make_one):
     venv, dir_ = make_one()
     assert len(venv.bin_paths) == 1
-    assert dir_.join("Scripts").strpath == venv.bin_paths[0]
+    assert venv.bin_paths[0] == venv.bin
+    assert dir_.join("Scripts").strpath == venv.bin
 
 
 def test_create(make_one):


### PR DESCRIPTION
Changelog (should I commit it in the changelog file ?)

 - Virtual environments now have a `bin_paths` attribute instead of a single `bin`. `command.run` and `which` both have their `path` argument renamed `paths` and supporting a list of paths, to handle it. 

 - Fixed the default paths for conda on windows where the `python.exe` found was not the correct one. Fixes #256
