### PR TITLE
`conda_install` and `install` args are now automatically double-quoted when needed.

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -76,7 +76,9 @@ def _dblquote_pkg_install_args(args):
     def _dblquote_pkg_install_arg(pkg_req_str):
         # sanity check: we need an even number of double-quotes
         if pkg_req_str.count('"') % 2 != 0:
-            raise ValueError("ill-formated argument with odd number of quotes: %s" % pkg_req_str)
+            raise ValueError(
+                "ill-formated argument with odd number of quotes: %s" % pkg_req_str
+            )
 
         if "<" in pkg_req_str or ">" in pkg_req_str:
             if pkg_req_str[0] == '"' and pkg_req_str[-1] == '"':

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -359,8 +359,8 @@ class Session:
         if not args:
             raise ValueError("At least one argument required to install().")
 
-        # Escape args that should be
-        args = _dblquote_pkg_install_args(args)
+        # Escape args that should be: not needed and would make pip raise an InvalidRequirement
+        # args = _dblquote_pkg_install_args(args)
 
         if "silent" not in kwargs:
             kwargs["silent"] = True

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -74,14 +74,16 @@ def _dblquote_pkg_install_args(args):
 
     # routine used to handle a single arg
     def _dblquote_pkg_install_arg(pkg_req_str):
-        if '<' in pkg_req_str or '>' in pkg_req_str:
+        if "<" in pkg_req_str or ">" in pkg_req_str:
             if pkg_req_str[0] == '"':
                 # already double-quoted string
                 return pkg_req_str
             else:
                 # need to double-quote string
                 if '"' in pkg_req_str:
-                    raise ValueError("Cannot escape requirement string: %s" % pkg_req_str)
+                    raise ValueError(
+                        "Cannot escape requirement string: %s" % pkg_req_str
+                    )
                 return '"%s"' % pkg_req_str
         else:
             # no dangerous char: no need to double-quote string

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -74,8 +74,12 @@ def _dblquote_pkg_install_args(args):
 
     # routine used to handle a single arg
     def _dblquote_pkg_install_arg(pkg_req_str):
+        # sanity check: we need an even number of double-quotes
+        if pkg_req_str.count('"') % 2 != 0:
+            raise ValueError("ill-formated argument with odd number of quotes: %s" % pkg_req_str)
+
         if "<" in pkg_req_str or ">" in pkg_req_str:
-            if pkg_req_str[0] == '"':
+            if pkg_req_str[0] == '"' and pkg_req_str[-1] == '"':
                 # already double-quoted string
                 return pkg_req_str
             else:

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -24,6 +24,7 @@ from typing import (
     Callable,
     Dict,
     Iterable,
+    Tuple,
     List,
     Mapping,
     Optional,
@@ -69,11 +70,11 @@ def _normalize_path(envdir: str, path: Union[str, bytes]) -> str:
     return full_path
 
 
-def _dblquote_pkg_install_args(args):
+def _dblquote_pkg_install_args(args: Tuple[str, ...]) -> Tuple[str, ...]:
     """Double-quote package install arguments in case they contain '>' or '<' symbols"""
 
     # routine used to handle a single arg
-    def _dblquote_pkg_install_arg(pkg_req_str):
+    def _dblquote_pkg_install_arg(pkg_req_str: str) -> str:
         # sanity check: we need an even number of double-quotes
         if pkg_req_str.count('"') % 2 != 0:
             raise ValueError(
@@ -96,7 +97,7 @@ def _dblquote_pkg_install_args(args):
             return pkg_req_str
 
     # double-quote all args that need to be and return the result
-    return [_dblquote_pkg_install_arg(a) for a in args]
+    return tuple(_dblquote_pkg_install_arg(a) for a in args)
 
 
 class _SessionQuit(Exception):

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -24,7 +24,6 @@ from typing import (
     Callable,
     Dict,
     Iterable,
-    Tuple,
     List,
     Mapping,
     Optional,
@@ -351,7 +350,7 @@ class Session:
         if not args:
             raise ValueError("At least one argument required to install().")
 
-        # Escape args that should be
+        # Escape args that should be (conda-specific; pip install does not need this)
         args = _dblquote_pkg_install_args(args)
 
         if "silent" not in kwargs:
@@ -394,9 +393,6 @@ class Session:
             )
         if not args:
             raise ValueError("At least one argument required to install().")
-
-        # Escape args that should be: not needed and would make pip raise an InvalidRequirement
-        # args = _dblquote_pkg_install_args(args)
 
         if "silent" not in kwargs:
             kwargs["silent"] = True

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -69,6 +69,28 @@ def _normalize_path(envdir: str, path: Union[str, bytes]) -> str:
     return full_path
 
 
+def _dblquote_pkg_install_args(args):
+    """Double-quote package install arguments in case they contain '>' or '<' symbols"""
+
+    # routine used to handle a single arg
+    def _dblquote_pkg_install_arg(pkg_req_str):
+        if '<' in pkg_req_str or '>' in pkg_req_str:
+            if pkg_req_str[0] == '"':
+                # already double-quoted string
+                return pkg_req_str
+            else:
+                # need to double-quote string
+                if '"' in pkg_req_str:
+                    raise ValueError("Cannot escape requirement string: %s" % pkg_req_str)
+                return '"%s"' % pkg_req_str
+        else:
+            # no dangerous char: no need to double-quote string
+            return pkg_req_str
+
+    # double-quote all args that need to be and return the result
+    return [_dblquote_pkg_install_arg(a) for a in args]
+
+
 class _SessionQuit(Exception):
     pass
 
@@ -279,6 +301,9 @@ class Session:
         if not args:
             raise ValueError("At least one argument required to install().")
 
+        # Escape args that should be
+        args = _dblquote_pkg_install_args(args)
+
         if "silent" not in kwargs:
             kwargs["silent"] = True
 
@@ -324,6 +349,9 @@ class Session:
             )
         if not args:
             raise ValueError("At least one argument required to install().")
+
+        # Escape args that should be
+        args = _dblquote_pkg_install_args(args)
 
         if "silent" not in kwargs:
             kwargs["silent"] = True

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -294,7 +294,7 @@ class TestSession:
     def test_conda_install_bad_args_odd_nb_double_quotes(self):
         session, runner = self.make_session_and_runner()
         runner.venv = mock.create_autospec(nox.virtualenv.CondaEnv)
-        runner.venv.location = './not/a/location'
+        runner.venv.location = "./not/a/location"
 
         with pytest.raises(ValueError, match="odd number of quotes"):
             session.conda_install('a"a')
@@ -302,7 +302,7 @@ class TestSession:
     def test_conda_install_bad_args_cannot_escape(self):
         session, runner = self.make_session_and_runner()
         runner.venv = mock.create_autospec(nox.virtualenv.CondaEnv)
-        runner.venv.location = './not/a/location'
+        runner.venv.location = "./not/a/location"
 
         with pytest.raises(ValueError, match="Cannot escape"):
             session.conda_install('a"o"<a')

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -290,7 +290,9 @@ class TestSession:
             )
 
     @pytest.mark.parametrize(
-        "version_constraint", ['no', 'yes', 'already_dbl_quoted'], ids="version_constraint={}".format
+        "version_constraint",
+        ["no", "yes", "already_dbl_quoted"],
+        ids="version_constraint={}".format,
     )
     def test_conda_install_non_default_kwargs(self, version_constraint):
         runner = nox.sessions.SessionRunner(
@@ -315,7 +317,7 @@ class TestSession:
             pkg_requirement = "urllib3<1.25"
             passed_arg = '"%s"' % pkg_requirement
         elif version_constraint == "already_dbl_quoted":
-            pkg_requirement = passed_arg = "\"urllib3<1.25\""
+            pkg_requirement = passed_arg = '"urllib3<1.25"'
         else:
             raise ValueError(version_constraint)
 
@@ -344,13 +346,13 @@ class TestSession:
         session, _ = self.make_session_and_runner()
 
         with pytest.raises(ValueError, match="odd number of quotes"):
-            session.install("a\"a")
+            session.install('a"a')
 
     def test_install_bad_args_cannot_escape(self):
         session, _ = self.make_session_and_runner()
 
         with pytest.raises(ValueError, match="Cannot escape"):
-            session.install("a\"o\"a")
+            session.install('a"o"a')
 
     def test_install_not_a_virtualenv(self):
         session, runner = self.make_session_and_runner()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -289,7 +289,9 @@ class TestSession:
                 external="error",
             )
 
-    @pytest.mark.parametrize("version_constraint", [False, True], ids="version_constraint={}".format)
+    @pytest.mark.parametrize(
+        "version_constraint", [False, True], ids="version_constraint={}".format
+    )
     def test_conda_install_non_default_kwargs(self, version_constraint):
         runner = nox.sessions.SessionRunner(
             name="test",

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -250,6 +250,20 @@ class TestSession:
         with pytest.raises(ValueError, match="arg"):
             session.conda_install()
 
+    def test_conda_install_bad_args_odd_nb_double_quotes(self):
+        session, runner = self.make_session_and_runner()
+        runner.venv = mock.create_autospec(nox.virtualenv.CondaEnv)
+
+        with pytest.raises(ValueError, match="odd number of quotes"):
+            session.conda_install('a"a')
+
+    def test_conda_install_bad_args_cannot_escape(self):
+        session, runner = self.make_session_and_runner()
+        runner.venv = mock.create_autospec(nox.virtualenv.CondaEnv)
+
+        with pytest.raises(ValueError, match="Cannot escape"):
+            session.conda_install('a"o"<a')
+
     def test_conda_install_not_a_condaenv(self):
         session, runner = self.make_session_and_runner()
 
@@ -341,18 +355,6 @@ class TestSession:
 
         with pytest.raises(ValueError, match="arg"):
             session.install()
-
-    def test_install_bad_args_odd_nb_double_quotes(self):
-        session, _ = self.make_session_and_runner()
-
-        with pytest.raises(ValueError, match="odd number of quotes"):
-            session.install('a"a')
-
-    def test_install_bad_args_cannot_escape(self):
-        session, _ = self.make_session_and_runner()
-
-        with pytest.raises(ValueError, match="Cannot escape"):
-            session.install('a"o"<a')
 
     def test_install_not_a_virtualenv(self):
         session, runner = self.make_session_and_runner()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -289,7 +289,8 @@ class TestSession:
                 external="error",
             )
 
-    def test_conda_install_non_default_kwargs(self):
+    @pytest.mark.parametrize("version_constraint", [False, True], ids="version_constraint={}".format)
+    def test_conda_install_non_default_kwargs(self, version_constraint):
         runner = nox.sessions.SessionRunner(
             name="test",
             signatures=["test"],
@@ -305,9 +306,9 @@ class TestSession:
             pass
 
         session = SessionNoSlots(runner=runner)
-
+        pkg_requirement = "urllib3<1.25" if version_constraint else "urllib3"
         with mock.patch.object(session, "_run", autospec=True) as run:
-            session.conda_install("requests", "urllib3", silent=False)
+            session.conda_install("requests", pkg_requirement, silent=False)
             run.assert_called_once_with(
                 "conda",
                 "install",
@@ -315,7 +316,8 @@ class TestSession:
                 "--prefix",
                 "/path/to/conda/env",
                 "requests",
-                "urllib3",
+                # double quoted if constraint is present
+                '"%s"' % pkg_requirement if version_constraint else pkg_requirement,
                 silent=False,
                 external="error",
             )

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -294,6 +294,7 @@ class TestSession:
     def test_conda_install_bad_args_odd_nb_double_quotes(self):
         session, runner = self.make_session_and_runner()
         runner.venv = mock.create_autospec(nox.virtualenv.CondaEnv)
+        runner.venv.location = './not/a/location'
 
         with pytest.raises(ValueError, match="odd number of quotes"):
             session.conda_install('a"a')
@@ -301,6 +302,7 @@ class TestSession:
     def test_conda_install_bad_args_cannot_escape(self):
         session, runner = self.make_session_and_runner()
         runner.venv = mock.create_autospec(nox.virtualenv.CondaEnv)
+        runner.venv.location = './not/a/location'
 
         with pytest.raises(ValueError, match="Cannot escape"):
             session.conda_install('a"o"<a')

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -352,7 +352,7 @@ class TestSession:
         session, _ = self.make_session_and_runner()
 
         with pytest.raises(ValueError, match="Cannot escape"):
-            session.install('a"o"a')
+            session.install('a"o"<a')
 
     def test_install_not_a_virtualenv(self):
         session, runner = self.make_session_and_runner()


### PR DESCRIPTION
Changelog (let me know if I should commit it somewhere):

 - `conda_install` ~~and `install`~~ args are now automatically double-quoted when they contain a `<` or a `>`. Fixes #311
