### PR TITLE
`venv_backend` new options and choices

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -132,7 +132,7 @@ Will produce these sessions:
 
 Note that this expansion happens *before* parameterization occurs, so you can still parametrize sessions with multiple interpreters.
 
-If you want to disable virtualenv creation altogether, you can set ``python`` to ``False``, or set `venv_backend` to ``"none"``, both are equivalent.
+If you want to disable virtualenv creation altogether, you can set ``python`` to ``False``, or set ``venv_backend`` to ``"none"``, both are equivalent. Note that this can be done temporarily through the :ref:`--no-venv <opt-force-venv-backend>` commandline flag, too.
 
 .. code-block:: python
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -375,7 +375,7 @@ The following options can be specified in the Noxfile:
 * ``nox.options.sessions`` is equivalent to specifying :ref:`-s or --sessions <opt-sessions-pythons-and-keywords>`.
 * ``nox.options.pythons`` is equivalent to specifying :ref:`-p or --pythons <opt-sessions-pythons-and-keywords>`.
 * ``nox.options.keywords`` is equivalent to specifying :ref:`-k or --keywords <opt-sessions-pythons-and-keywords>`.
-* ``nox.options.venv_backend`` is equivalent to specifying :ref:`-vb or --venv_backend <opt-default-venv_backend>`.
+* ``nox.options.venv_backend`` is equivalent to specifying :ref:`-vb or --venv_backend <opt-default-venv-backend>`.
 * ``nox.options.reuse_existing_virtualenvs`` is equivalent to specifying :ref:`--reuse-existing-virtualenvs <opt-reuse-existing-virtualenvs>`. You can force this off by specifying ``--no-reuse-existing-virtualenvs`` during invocation.
 * ``nox.options.stop_on_first_error`` is equivalent to specifying :ref:`--stop-on-first-error <opt-stop-on-first-error>`. You can force this off by specifying ``--no-stop-on-first-error`` during invocation.
 * ``nox.options.error_on_missing_interpreters`` is equivalent to specifying :ref:`--error-on-missing-interpreters <opt-error-on-missing-interpreters>`. You can force this off by specifying ``--no-error-on-missing-interpreters`` during invocation.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -375,6 +375,7 @@ The following options can be specified in the Noxfile:
 * ``nox.options.sessions`` is equivalent to specifying :ref:`-s or --sessions <opt-sessions-pythons-and-keywords>`.
 * ``nox.options.pythons`` is equivalent to specifying :ref:`-p or --pythons <opt-sessions-pythons-and-keywords>`.
 * ``nox.options.keywords`` is equivalent to specifying :ref:`-k or --keywords <opt-sessions-pythons-and-keywords>`.
+* ``nox.options.venv_backend`` is equivalent to specifying :ref:`-vb or --venv_backend <opt-default-venv_backend>`.
 * ``nox.options.reuse_existing_virtualenvs`` is equivalent to specifying :ref:`--reuse-existing-virtualenvs <opt-reuse-existing-virtualenvs>`. You can force this off by specifying ``--no-reuse-existing-virtualenvs`` during invocation.
 * ``nox.options.stop_on_first_error`` is equivalent to specifying :ref:`--stop-on-first-error <opt-stop-on-first-error>`. You can force this off by specifying ``--no-stop-on-first-error`` during invocation.
 * ``nox.options.error_on_missing_interpreters`` is equivalent to specifying :ref:`--error-on-missing-interpreters <opt-error-on-missing-interpreters>`. You can force this off by specifying ``--no-error-on-missing-interpreters`` during invocation.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -132,7 +132,7 @@ Will produce these sessions:
 
 Note that this expansion happens *before* parameterization occurs, so you can still parametrize sessions with multiple interpreters.
 
-If you want to disable virtualenv creation altogether, you can set ``python`` to ``False``:
+If you want to disable virtualenv creation altogether, you can set ``python`` to ``False``, or set `venv_backend` to ``"none"``, both are equivalent.
 
 .. code-block:: python
 
@@ -375,7 +375,8 @@ The following options can be specified in the Noxfile:
 * ``nox.options.sessions`` is equivalent to specifying :ref:`-s or --sessions <opt-sessions-pythons-and-keywords>`.
 * ``nox.options.pythons`` is equivalent to specifying :ref:`-p or --pythons <opt-sessions-pythons-and-keywords>`.
 * ``nox.options.keywords`` is equivalent to specifying :ref:`-k or --keywords <opt-sessions-pythons-and-keywords>`.
-* ``nox.options.venv_backend`` is equivalent to specifying :ref:`-vb or --venv_backend <opt-default-venv-backend>`.
+* ``nox.options.default_venv_backend`` is equivalent to specifying :ref:`-db or --default-venv-backend <opt-default-venv-backend>`.
+* ``nox.options.force_venv_backend`` is equivalent to specifying :ref:`-fb or --force-venv-backend <opt-force-venv-backend>`.
 * ``nox.options.reuse_existing_virtualenvs`` is equivalent to specifying :ref:`--reuse-existing-virtualenvs <opt-reuse-existing-virtualenvs>`. You can force this off by specifying ``--no-reuse-existing-virtualenvs`` during invocation.
 * ``nox.options.stop_on_first_error`` is equivalent to specifying :ref:`--stop-on-first-error <opt-stop-on-first-error>`. You can force this off by specifying ``--no-stop-on-first-error`` during invocation.
 * ``nox.options.error_on_missing_interpreters`` is equivalent to specifying :ref:`--error-on-missing-interpreters <opt-error-on-missing-interpreters>`. You can force this off by specifying ``--no-error-on-missing-interpreters`` during invocation.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -138,6 +138,11 @@ You might work in a different environment than a project's default continuous in
 
 You can also set this option in the Noxfile with ``nox.options.force_venv_backend``. In case both are provided, the commandline argument takes precedence.
 
+Finally note that the ``--no-venv`` flag is a shortcut for ``--force-venv-backend none`` and allows to temporarily run all selected sessions on the current python interpreter (the one running nox).
+
+.. code-block:: console
+
+    nox --no-venv
 
 .. _opt-reuse-existing-virtualenvs:
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -105,6 +105,24 @@ Then running ``nox --session tests`` will actually run all parametrized versions
     nox --session "tests(django='2.0')"
 
 
+.. opt-default-venv_backend:
+
+Changing the sessions default backend
+-------------------------------------
+
+By default nox uses ``virtualenv`` as the virtual environment backend for the sessions, but it also supports ``conda`` and ``venv``. You can change the default behaviour by using ``-vb <backend>`` or ``--venv_backend <backend>``. Supported names are ``('virtualenv', 'conda', 'venv')``.
+
+.. code-block:: console
+
+    nox -vb conda
+    nox --venv_backend conda
+
+
+You can also set this option in the Noxfile with ``nox.options.venv_backend``. In case both are provided, the commandline argument takes precedence.
+
+Note that using this option does not change the backend for sessions where ``venv_backend`` is explicitly set.
+
+
 .. _opt-reuse-existing-virtualenvs:
 
 Re-using virtualenvs

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -105,7 +105,7 @@ Then running ``nox --session tests`` will actually run all parametrized versions
     nox --session "tests(django='2.0')"
 
 
-.. opt-default-venv_backend:
+.. _opt-default-venv-backend:
 
 Changing the sessions default backend
 -------------------------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -149,7 +149,7 @@ Finally note that the ``--no-venv`` flag is a shortcut for ``--force-venv-backen
 Re-using virtualenvs
 --------------------
 
-By default, nox deletes and recreates virtualenvs every time it is run. This is usually fine for most projects and continuous integration environments as `pip's caching <https://pip.pypa.io/en/stable/reference/pip_install/#caching>`_ makes re-install rather quick. However, there are some situations where it is advantageous to re-use the virtualenvs between runs. Use ``-r`` or ``--reuse-existing-virtualenvs``:
+By default, Nox deletes and recreates virtualenvs every time it is run. This is usually fine for most projects and continuous integration environments as `pip's caching <https://pip.pypa.io/en/stable/reference/pip_install/#caching>`_ makes re-install rather quick. However, there are some situations where it is advantageous to re-use the virtualenvs between runs. Use ``-r`` or ``--reuse-existing-virtualenvs``:
 
 .. code-block:: console
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -149,7 +149,7 @@ Finally note that the ``--no-venv`` flag is a shortcut for ``--force-venv-backen
 Re-using virtualenvs
 --------------------
 
-By default nox deletes and recreates virtualenvs every time it is run. This is usually fine for most projects and continuous integration environments as `pip's caching <https://pip.pypa.io/en/stable/reference/pip_install/#caching>`_ makes re-install rather quick. However, there are some situations where it is advantageous to re-use the virtualenvs between runs. Use ``-r`` or ``--reuse-existing-virtualenvs``:
+By default, nox deletes and recreates virtualenvs every time it is run. This is usually fine for most projects and continuous integration environments as `pip's caching <https://pip.pypa.io/en/stable/reference/pip_install/#caching>`_ makes re-install rather quick. However, there are some situations where it is advantageous to re-use the virtualenvs between runs. Use ``-r`` or ``--reuse-existing-virtualenvs``:
 
 .. code-block:: console
 

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -110,17 +110,33 @@ Then running ``nox --session tests`` will actually run all parametrized versions
 Changing the sessions default backend
 -------------------------------------
 
-By default nox uses ``virtualenv`` as the virtual environment backend for the sessions, but it also supports ``conda`` and ``venv``. You can change the default behaviour by using ``-vb <backend>`` or ``--venv_backend <backend>``. Supported names are ``('virtualenv', 'conda', 'venv')``.
+By default nox uses ``virtualenv`` as the virtual environment backend for the sessions, but it also supports ``conda`` and ``venv`` as well as no backend (passthrough to whatever python environment nox is running on). You can change the default behaviour by using ``-db <backend>`` or ``--default-venv-backend <backend>``. Supported names are ``('none', 'virtualenv', 'conda', 'venv')``.
 
 .. code-block:: console
 
-    nox -vb conda
-    nox --venv_backend conda
+    nox -db conda
+    nox --default-venv-backend conda
 
 
-You can also set this option in the Noxfile with ``nox.options.venv_backend``. In case both are provided, the commandline argument takes precedence.
+You can also set this option in the Noxfile with ``nox.options.default_venv_backend``. In case both are provided, the commandline argument takes precedence.
 
 Note that using this option does not change the backend for sessions where ``venv_backend`` is explicitly set.
+
+
+.. _opt-force-venv-backend:
+
+Forcing the sessions backend
+----------------------------
+
+You might work in a different environment than a project's default continuous integration setttings, and might wish to get a quick way to execute the same tasks but on a different venv backend. For this purpose, you can temporarily force the backend used by **all** sessions in the current nox execution by using ``-fb <backend>`` or ``--force-venv-backend <backend>``. No exceptions are made, the backend will be forced for all sessions run whatever the other options values and nox file configuration. Supported names are ``('none', 'virtualenv', 'conda', 'venv')``.
+
+.. code-block:: console
+
+    nox -fb conda
+    nox --force-venv-backend conda
+
+
+You can also set this option in the Noxfile with ``nox.options.force_venv_backend``. In case both are provided, the commandline argument takes precedence.
 
 
 .. _opt-reuse-existing-virtualenvs:

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -1,7 +1,7 @@
 import copy
 import functools
 import types
-from typing import Any, Callable, Iterable, List, Optional, cast
+from typing import Any, Callable, Iterable, List, Dict, Optional, cast
 
 from . import _typing
 
@@ -40,12 +40,14 @@ class Func(FunctionDecorator):
         name: Optional[str] = None,
         venv_backend: Any = None,
         venv_params: Any = None,
+        should_warn: Dict[str, Any] = None,
     ):
         self.func = func
         self.python = python
         self.reuse_venv = reuse_venv
         self.venv_backend = venv_backend
         self.venv_params = venv_params
+        self.should_warn = should_warn or dict()
 
     def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return self.func(*args, **kwargs)

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -60,6 +60,7 @@ class Func(FunctionDecorator):
             name,
             self.venv_backend,
             self.venv_params,
+            self.should_warn
         )
 
 
@@ -72,6 +73,7 @@ class Call(Func):
             None,
             func.venv_backend,
             func.venv_params,
+            func.should_warn
         )
         self.param_spec = param_spec
         self.session_signature = "({})".format(param_spec)

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -60,7 +60,7 @@ class Func(FunctionDecorator):
             name,
             self.venv_backend,
             self.venv_params,
-            self.should_warn
+            self.should_warn,
         )
 
 
@@ -73,7 +73,7 @@ class Call(Func):
             None,
             func.venv_backend,
             func.venv_params,
-            func.should_warn
+            func.should_warn,
         )
         self.param_spec = param_spec
         self.session_signature = "({})".format(param_spec)

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -159,12 +159,6 @@ def _session_completer(
     ]
 
 
-def _venv_backend_completer(
-    prefix: str, parsed_args: argparse.Namespace, **kwargs: Any
-) -> List[str]:
-    return ["virtualenv", "conda", "venv"]
-
-
 options.add_options(
     _option_set.Option(
         "help",
@@ -250,7 +244,7 @@ options.add_options(
         merge_func=_venv_backend_merge_func,
         help="Virtual environment backend to use by default for nox sessions, this is ``'virtualenv'`` by default but "
         "any of ``('virtualenv', 'conda', 'venv')`` are accepted.",
-        completer=_venv_backend_completer,
+        choices=["virtualenv", "conda", "venv"]
     ),
     *_option_set.make_flag_pair(
         "reuse_existing_virtualenvs",

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -162,7 +162,7 @@ def _session_completer(
 def _venv_backend_completer(
     prefix: str, parsed_args: argparse.Namespace, **kwargs: Any
 ) -> List[str]:
-    return ['virtualenv', 'conda', 'venv']
+    return ["virtualenv", "conda", "venv"]
 
 
 options.add_options(
@@ -249,7 +249,7 @@ options.add_options(
         noxfile=True,
         merge_func=_venv_backend_merge_func,
         help="Virtual environment backend to use by default for nox sessions, this is ``'virtualenv'`` by default but "
-             "any of ``('virtualenv', 'conda', 'venv')`` are accepted.",
+        "any of ``('virtualenv', 'conda', 'venv')`` are accepted.",
         completer=_venv_backend_completer,
     ),
     *_option_set.make_flag_pair(

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -258,7 +258,7 @@ options.add_options(
         merge_func=_default_venv_backend_merge_func,
         help="Virtual environment backend to use by default for nox sessions, this is ``'virtualenv'`` by default but "
         "any of ``('virtualenv', 'conda', 'venv')`` are accepted.",
-        choices=["virtualenv", "conda", "venv"]
+        choices=["none", "virtualenv", "conda", "venv"]
     ),
     _option_set.Option(
         "force_venv_backend",
@@ -270,7 +270,7 @@ options.add_options(
         help="Virtual environment backend to force-use for all nox sessions in this run, overriding any other venv "
         "backend declared in the nox file and ignoring the default backend. Any of ``('virtualenv', 'conda', 'venv')`` "
         "are accepted.",
-        choices=["virtualenv", "conda", "venv"]
+        choices=["none", "virtualenv", "conda", "venv"]
     ),
     *_option_set.make_flag_pair(
         "reuse_existing_virtualenvs",

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -90,8 +90,13 @@ def _force_venv_backend_merge_func(
             Noxfile.
     """
     if command_args.no_venv:
-        if command_args.force_venv_backend is not None and command_args.force_venv_backend != "none":
-            raise ValueError("You can not use `--no-venv` with a non-none `--force-venv-backend`")
+        if (
+            command_args.force_venv_backend is not None
+            and command_args.force_venv_backend != "none"
+        ):
+            raise ValueError(
+                "You can not use `--no-venv` with a non-none `--force-venv-backend`"
+            )
         else:
             return "none"
     else:

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -71,7 +71,11 @@ def _default_venv_backend_merge_func(
         noxfile_Args (_option_set.Namespace): The options specified in the
             Noxfile.
     """
-    return command_args.default_venv_backend or noxfile_args.default_venv_backend or "virtualenv"
+    return (
+        command_args.default_venv_backend
+        or noxfile_args.default_venv_backend
+        or "virtualenv"
+    )
 
 
 def _force_venv_backend_merge_func(
@@ -258,7 +262,7 @@ options.add_options(
         merge_func=_default_venv_backend_merge_func,
         help="Virtual environment backend to use by default for nox sessions, this is ``'virtualenv'`` by default but "
         "any of ``('virtualenv', 'conda', 'venv')`` are accepted.",
-        choices=["none", "virtualenv", "conda", "venv"]
+        choices=["none", "virtualenv", "conda", "venv"],
     ),
     _option_set.Option(
         "force_venv_backend",
@@ -270,7 +274,7 @@ options.add_options(
         help="Virtual environment backend to force-use for all nox sessions in this run, overriding any other venv "
         "backend declared in the nox file and ignoring the default backend. Any of ``('virtualenv', 'conda', 'venv')`` "
         "are accepted.",
-        choices=["none", "virtualenv", "conda", "venv"]
+        choices=["none", "virtualenv", "conda", "venv"],
     ),
     *_option_set.make_flag_pair(
         "reuse_existing_virtualenvs",

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -89,7 +89,13 @@ def _force_venv_backend_merge_func(
         noxfile_Args (_option_set.Namespace): The options specified in the
             Noxfile.
     """
-    return command_args.force_venv_backend or noxfile_args.force_venv_backend
+    if command_args.no_venv:
+        if command_args.force_venv_backend is not None and command_args.force_venv_backend != "none":
+            raise ValueError("You can not use `--no-venv` with a non-none `--force-venv-backend`")
+        else:
+            return "none"
+    else:
+        return command_args.force_venv_backend or noxfile_args.force_venv_backend
 
 
 def _envdir_merge_func(
@@ -275,6 +281,15 @@ options.add_options(
         "backend declared in the nox file and ignoring the default backend. Any of ``('virtualenv', 'conda', 'venv')`` "
         "are accepted.",
         choices=["none", "virtualenv", "conda", "venv"],
+    ),
+    _option_set.Option(
+        "no_venv",
+        "--no-venv",
+        group=options.groups["secondary"],
+        default=False,
+        action="store_true",
+        help="Runs the selected sessions directly on the current interpreter, without creating a venv. This is an alias "
+        "for '--force-venv-backend none'.",
     ),
     *_option_set.make_flag_pair(
         "reuse_existing_virtualenvs",

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -60,6 +60,20 @@ def _session_filters_merge_func(
     return getattr(command_args, key)
 
 
+def _venv_backend_merge_func(
+    command_args: argparse.Namespace, noxfile_args: argparse.Namespace
+) -> str:
+    """Ensure that there is always some venv_backend.
+
+    Args:
+        command_args (_option_set.Namespace): The options specified on the
+            command-line.
+        noxfile_Args (_option_set.Namespace): The options specified in the
+            Noxfile.
+    """
+    return command_args.venv_backend or noxfile_args.venv_backend or "virtualenv"
+
+
 def _envdir_merge_func(
     command_args: argparse.Namespace, noxfile_args: argparse.Namespace
 ) -> str:
@@ -145,6 +159,12 @@ def _session_completer(
     ]
 
 
+def _venv_backend_completer(
+    prefix: str, parsed_args: argparse.Namespace, **kwargs: Any
+) -> List[str]:
+    return ['virtualenv', 'conda', 'venv']
+
+
 options.add_options(
     _option_set.Option(
         "help",
@@ -220,6 +240,17 @@ options.add_options(
         action="store_true",
         help="Logs the output of all commands run including commands marked silent.",
         noxfile=True,
+    ),
+    _option_set.Option(
+        "venv_backend",
+        "-vb",
+        "--venv_backend",
+        group=options.groups["secondary"],
+        noxfile=True,
+        merge_func=_venv_backend_merge_func,
+        help="Virtual environment backend to use by default for nox sessions, this is ``'virtualenv'`` by default but "
+             "any of ``('virtualenv', 'conda', 'venv')`` are accepted.",
+        completer=_venv_backend_completer,
     ),
     *_option_set.make_flag_pair(
         "reuse_existing_virtualenvs",

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -60,10 +60,10 @@ def _session_filters_merge_func(
     return getattr(command_args, key)
 
 
-def _venv_backend_merge_func(
+def _default_venv_backend_merge_func(
     command_args: argparse.Namespace, noxfile_args: argparse.Namespace
 ) -> str:
-    """Ensure that there is always some venv_backend.
+    """Merge default_venv_backend from command args and nox file. Default is "virtualenv".
 
     Args:
         command_args (_option_set.Namespace): The options specified on the
@@ -71,7 +71,21 @@ def _venv_backend_merge_func(
         noxfile_Args (_option_set.Namespace): The options specified in the
             Noxfile.
     """
-    return command_args.venv_backend or noxfile_args.venv_backend or "virtualenv"
+    return command_args.default_venv_backend or noxfile_args.default_venv_backend or "virtualenv"
+
+
+def _force_venv_backend_merge_func(
+    command_args: argparse.Namespace, noxfile_args: argparse.Namespace
+) -> str:
+    """Merge force_venv_backend from command args and nox file. Default is None.
+
+    Args:
+        command_args (_option_set.Namespace): The options specified on the
+            command-line.
+        noxfile_Args (_option_set.Namespace): The options specified in the
+            Noxfile.
+    """
+    return command_args.force_venv_backend or noxfile_args.force_venv_backend
 
 
 def _envdir_merge_func(
@@ -236,14 +250,26 @@ options.add_options(
         noxfile=True,
     ),
     _option_set.Option(
-        "venv_backend",
-        "-vb",
-        "--venv_backend",
+        "default_venv_backend",
+        "-db",
+        "--default-venv-backend",
         group=options.groups["secondary"],
         noxfile=True,
-        merge_func=_venv_backend_merge_func,
+        merge_func=_default_venv_backend_merge_func,
         help="Virtual environment backend to use by default for nox sessions, this is ``'virtualenv'`` by default but "
         "any of ``('virtualenv', 'conda', 'venv')`` are accepted.",
+        choices=["virtualenv", "conda", "venv"]
+    ),
+    _option_set.Option(
+        "force_venv_backend",
+        "-fb",
+        "--force-venv-backend",
+        group=options.groups["secondary"],
+        noxfile=True,
+        merge_func=_force_venv_backend_merge_func,
+        help="Virtual environment backend to force-use for all nox sessions in this run, overriding any other venv "
+        "backend declared in the nox file and ignoring the default backend. Any of ``('virtualenv', 'conda', 'venv')`` "
+        "are accepted.",
         choices=["virtualenv", "conda", "venv"]
     ),
     *_option_set.make_flag_pair(

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -18,6 +18,7 @@ import itertools
 from typing import Any, Iterable, Iterator, List, Mapping, Sequence, Set, Tuple, Union
 
 from nox._decorators import Call, Func
+from nox.logger import logger
 from nox.sessions import Session, SessionRunner
 
 
@@ -169,6 +170,12 @@ class Manifest:
                 bound to this manifest and configuration.
         """
         sessions = []
+
+        # if backend is none we wont parametrize the pythons
+        backend = self._config.force_venv_backend or func.venv_backend or self._config.default_venv_backend
+        if backend == "none" and isinstance(func.python, (list, tuple, set)):
+            logger.warning("Running session '{}' with venv_backend='none', ignoring python={}".format(name, func.python))
+            func.python = False
 
         # If the func has the python attribute set to a list, we'll need
         # to expand them.

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -18,8 +18,10 @@ import itertools
 from typing import Any, Iterable, Iterator, List, Mapping, Sequence, Set, Tuple, Union
 
 from nox._decorators import Call, Func
-from nox.logger import logger
 from nox.sessions import Session, SessionRunner
+
+
+WARN_PYTHONS_IGNORED = "python_ignored"
 
 
 class Manifest:
@@ -178,11 +180,9 @@ class Manifest:
             or self._config.default_venv_backend
         )
         if backend == "none" and isinstance(func.python, (list, tuple, set)):
-            logger.warning(
-                "Running session '{}' with venv_backend='none', ignoring python={}".format(
-                    name, func.python
-                )
-            )
+            # we can not log a warning here since the session is maybe deselected.
+            # instead let's set a flag, to warn later when session is actually run.
+            func.should_warn[WARN_PYTHONS_IGNORED] = func.python
             func.python = False
 
         # If the func has the python attribute set to a list, we'll need

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -172,9 +172,17 @@ class Manifest:
         sessions = []
 
         # if backend is none we wont parametrize the pythons
-        backend = self._config.force_venv_backend or func.venv_backend or self._config.default_venv_backend
+        backend = (
+            self._config.force_venv_backend
+            or func.venv_backend
+            or self._config.default_venv_backend
+        )
         if backend == "none" and isinstance(func.python, (list, tuple, set)):
-            logger.warning("Running session '{}' with venv_backend='none', ignoring python={}".format(name, func.python))
+            logger.warning(
+                "Running session '{}' with venv_backend='none', ignoring python={}".format(
+                    name, func.python
+                )
+            )
             func.python = False
 
         # If the func has the python attribute set to a list, we'll need

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -398,21 +398,22 @@ class SessionRunner:
             self.func.reuse_venv or self.global_config.reuse_existing_virtualenvs
         )
 
-        if not self.func.venv_backend or self.func.venv_backend == "virtualenv":
+        backend = self.func.venv_backend or self.global_config.venv_backend
+        if backend == "virtualenv":
             self.venv = VirtualEnv(
                 path,
                 interpreter=self.func.python,  # type: ignore
                 reuse_existing=reuse_existing,
                 venv_params=self.func.venv_params,
             )
-        elif self.func.venv_backend == "conda":
+        elif backend == "conda":
             self.venv = CondaEnv(
                 path,
                 interpreter=self.func.python,  # type: ignore
                 reuse_existing=reuse_existing,
                 venv_params=self.func.venv_params,
             )
-        elif self.func.venv_backend == "venv":
+        elif backend == "venv":
             self.venv = VirtualEnv(
                 path,
                 interpreter=self.func.python,  # type: ignore
@@ -423,7 +424,7 @@ class SessionRunner:
         else:
             raise ValueError(
                 "Expected venv_backend one of ('virtualenv', 'conda', 'venv'), but got '{}'.".format(
-                    self.func.venv_backend
+                    backend
                 )
             )
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -399,7 +399,7 @@ class SessionRunner:
         )
 
         backend = self.func.venv_backend or self.global_config.venv_backend
-        if backend == "virtualenv":
+        if backend is None or backend == "virtualenv":
             self.venv = VirtualEnv(
                 path,
                 interpreter=self.func.python,  # type: ignore

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -398,7 +398,7 @@ class SessionRunner:
             self.func.reuse_venv or self.global_config.reuse_existing_virtualenvs
         )
 
-        backend = self.func.venv_backend or self.global_config.venv_backend
+        backend = self.global_config.force_venv_backend or self.func.venv_backend or self.global_config.default_venv_backend
         if backend is None or backend == "virtualenv":
             self.venv = VirtualEnv(
                 path,

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -389,7 +389,11 @@ class SessionRunner:
         return self.signatures[0] if self.signatures else self.name
 
     def _create_venv(self) -> None:
-        backend = self.global_config.force_venv_backend or self.func.venv_backend or self.global_config.default_venv_backend
+        backend = (
+            self.global_config.force_venv_backend
+            or self.func.venv_backend
+            or self.global_config.default_venv_backend
+        )
 
         if backend == "none" or self.func.python is False:
             self.venv = ProcessEnv()

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -389,7 +389,9 @@ class SessionRunner:
         return self.signatures[0] if self.signatures else self.name
 
     def _create_venv(self) -> None:
-        if self.func.python is False:
+        backend = self.global_config.force_venv_backend or self.func.venv_backend or self.global_config.default_venv_backend
+
+        if backend == "none" or self.func.python is False:
             self.venv = ProcessEnv()
             return
 
@@ -398,7 +400,6 @@ class SessionRunner:
             self.func.reuse_venv or self.global_config.reuse_existing_virtualenvs
         )
 
-        backend = self.global_config.force_venv_backend or self.func.venv_backend or self.global_config.default_venv_backend
         if backend is None or backend == "virtualenv":
             self.venv = VirtualEnv(
                 path,

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -237,7 +237,7 @@ def run_manifest(manifest: Manifest, global_config: Namespace) -> List[Result]:
         if WARN_PYTHONS_IGNORED in session.func.should_warn:
             logger.warning(
                 "Session {} is set to run with venv_backend='none', IGNORING its python={} parametrization. ".format(
-                    session.name, session.func.should_warn['python_ignored']
+                    session.name, session.func.should_warn[WARN_PYTHONS_IGNORED]
                 )
             )
 

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -24,7 +24,7 @@ import nox
 from colorlog.escape_codes import parse_colors
 from nox import _options, registry
 from nox.logger import logger
-from nox.manifest import Manifest
+from nox.manifest import Manifest, WARN_PYTHONS_IGNORED
 from nox.sessions import Result
 
 
@@ -233,6 +233,14 @@ def run_manifest(manifest: Manifest, global_config: Namespace) -> List[Result]:
     # Note that it is possible for the manifest to be altered in any given
     # iteration.
     for session in manifest:
+        # possibly raise warnings associated with this session
+        if WARN_PYTHONS_IGNORED in session.func.should_warn:
+            logger.warning(
+                "Session {} is set to run with venv_backend='none', IGNORING its python={} parametrization. ".format(
+                    session.name, session.func.should_warn['python_ignored']
+                )
+            )
+
         result = session.execute()
         result.log(
             "Session {name} {status}.".format(

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -141,6 +141,16 @@ def _clean_location(self: "Union[CondaEnv, VirtualEnv]") -> bool:
     return True
 
 
+class PassthroughEnv(ProcessEnv):
+    """Represents the environment used to run nox itself
+
+    For now, this class is empty but it might contain tools to grasp some
+    hints about the actual env.
+    """
+
+    pass
+
+
 class CondaEnv(ProcessEnv):
     """Conda environemnt management class.
 

--- a/tests/resources/noxfile_pythons.py
+++ b/tests/resources/noxfile_pythons.py
@@ -1,7 +1,7 @@
 import nox
 
 
-@nox.session(python=['3.6'])
+@nox.session(python=["3.6"])
 @nox.parametrize("cheese", ["cheddar", "jack", "brie"])
 def snack(unused_session, cheese):
     print("Noms, {} so good!".format(cheese))

--- a/tests/resources/noxfile_pythons.py
+++ b/tests/resources/noxfile_pythons.py
@@ -1,0 +1,7 @@
+import nox
+
+
+@nox.session(python=['3.6'])
+@nox.parametrize("cheese", ["cheddar", "jack", "brie"])
+def snack(unused_session, cheese):
+    print("Noms, {} so good!".format(cheese))

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -72,15 +72,15 @@ class TestOptionSet:
         assert len(all_nox_sessions) == 0
 
     def test_venv_backend_completer(self):
-        parsed_args = _options.options.namespace(venv_backend=(), keywords=())
+        parsed_args = _options.options.namespace(venv_backend=())
         all_nox_venv_backends = _options._venv_backend_completer(
             prefix=None, parsed_args=parsed_args
         )
         assert set(all_nox_venv_backends) == {'venv', 'conda', 'virtualenv'}
 
     def test_venv_backend_completer_invalid_venv_backends(self):
-        parsed_args = _options.options.namespace(venv_backend=("baz",), keywords=())
-        all_nox_venv_backends = _options._session_completer(
+        parsed_args = _options.options.namespace(venv_backend=("baz",))
+        all_nox_venv_backends = _options._venv_backend_completer(
             prefix=None, parsed_args=parsed_args
         )
         assert len(all_nox_venv_backends) == 0

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -70,17 +70,3 @@ class TestOptionSet:
             prefix=None, parsed_args=parsed_args
         )
         assert len(all_nox_sessions) == 0
-
-    def test_venv_backend_completer(self):
-        parsed_args = _options.options.namespace(venv_backend=())
-        all_nox_venv_backends = _options._venv_backend_completer(
-            prefix=None, parsed_args=parsed_args
-        )
-        assert set(all_nox_venv_backends) == {'venv', 'conda', 'virtualenv'}
-
-    def test_venv_backend_completer_invalid_venv_backends(self):
-        parsed_args = _options.options.namespace(venv_backend=("baz",))
-        all_nox_venv_backends = _options._venv_backend_completer(
-            prefix=None, parsed_args=parsed_args
-        )
-        assert len(all_nox_venv_backends) == 0

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -70,3 +70,17 @@ class TestOptionSet:
             prefix=None, parsed_args=parsed_args
         )
         assert len(all_nox_sessions) == 0
+
+    def test_venv_backend_completer(self):
+        parsed_args = _options.options.namespace(venv_backend=(), keywords=())
+        all_nox_venv_backends = _options._venv_backend_completer(
+            prefix=None, parsed_args=parsed_args
+        )
+        assert set(all_nox_venv_backends) == {'venv', 'conda', 'virtualenv'}
+
+    def test_venv_backend_completer_invalid_venv_backends(self):
+        parsed_args = _options.options.namespace(venv_backend=("baz",), keywords=())
+        all_nox_venv_backends = _options._session_completer(
+            prefix=None, parsed_args=parsed_args
+        )
+        assert len(all_nox_venv_backends) == 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -55,6 +55,7 @@ def test_main_no_args(monkeypatch):
         config = execute.call_args[1]["global_config"]
         assert config.noxfile == "noxfile.py"
         assert config.sessions is None
+        assert not config.no_venv
         assert not config.reuse_existing_virtualenvs
         assert not config.stop_on_first_error
         assert config.posargs == []
@@ -73,7 +74,8 @@ def test_main_long_form_args():
         "--default-venv-backend",
         "venv",
         "--force-venv-backend",
-        "conda",
+        "none",
+        "--no-venv",
         "--reuse-existing-virtualenvs",
         "--stop-on-first-error",
     ]
@@ -92,10 +94,25 @@ def test_main_long_form_args():
         assert config.envdir.endswith(".other")
         assert config.sessions == ["1", "2"]
         assert config.default_venv_backend == "venv"
-        assert config.force_venv_backend == "conda"
+        assert config.force_venv_backend == "none"
+        assert config.no_venv is True
         assert config.reuse_existing_virtualenvs is True
         assert config.stop_on_first_error is True
         assert config.posargs == []
+
+
+def test_main_no_venv_error():
+    # Check that -no-venv can not be set together with a non-none --force-venv-backend
+    sys.argv = [
+        sys.executable,
+        "--noxfile",
+        "noxfile.py",
+        "--force-venv-backend",
+        "conda",
+        "--no-venv",
+    ]
+    with pytest.raises(ValueError, match="You can not use"):
+        nox.__main__.main()
 
 
 def test_main_short_form_args(monkeypatch):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -101,8 +101,32 @@ def test_main_long_form_args():
         assert config.posargs == []
 
 
+def test_main_no_venv(monkeypatch, capsys):
+    # Check that --no-venv overrides force_venv_backend
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "nox",
+            "--noxfile",
+            os.path.join(RESOURCES, "noxfile_pythons.py"),
+            "--no-venv",
+            "-s",
+            "snack(cheese='cheddar')",
+        ],
+    )
+
+    with mock.patch("sys.exit") as sys_exit:
+        nox.__main__.main()
+        stdout, stderr = capsys.readouterr()
+        assert stdout == "Noms, cheddar so good!\n"
+        assert "Session snack is set to run with venv_backend='none', IGNORING its python" in stderr
+        assert "Session snack(cheese='cheddar') was successful." in stderr
+        sys_exit.assert_called_once_with(0)
+
+
 def test_main_no_venv_error():
-    # Check that -no-venv can not be set together with a non-none --force-venv-backend
+    # Check that --no-venv can not be set together with a non-none --force-venv-backend
     sys.argv = [
         sys.executable,
         "--noxfile",

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -70,8 +70,10 @@ def test_main_long_form_args():
         "--sessions",
         "1",
         "2",
-        "--venv_backend",
+        "--default-venv-backend",
         "venv",
+        "--force-venv-backend",
+        "conda",
         "--reuse-existing-virtualenvs",
         "--stop-on-first-error",
     ]
@@ -89,7 +91,8 @@ def test_main_long_form_args():
         assert config.noxfile == "noxfile.py"
         assert config.envdir.endswith(".other")
         assert config.sessions == ["1", "2"]
-        assert config.venv_backend == "venv"
+        assert config.default_venv_backend == "venv"
+        assert config.force_venv_backend == "conda"
         assert config.reuse_existing_virtualenvs is True
         assert config.stop_on_first_error is True
         assert config.posargs == []
@@ -97,7 +100,7 @@ def test_main_long_form_args():
 
 def test_main_short_form_args(monkeypatch):
     monkeypatch.setattr(
-        sys, "argv", [sys.executable, "-f", "noxfile.py", "-s", "1", "2", "-vb", "venv", "-r"]
+        sys, "argv", [sys.executable, "-f", "noxfile.py", "-s", "1", "2", "-db", "venv", "-fb", "conda", "-r"]
     )
     with mock.patch("nox.workflow.execute") as execute:
         execute.return_value = 0
@@ -112,7 +115,8 @@ def test_main_short_form_args(monkeypatch):
         config = execute.call_args[1]["global_config"]
         assert config.noxfile == "noxfile.py"
         assert config.sessions == ["1", "2"]
-        assert config.venv_backend == "venv"
+        assert config.default_venv_backend == "venv"
+        assert config.force_venv_backend == "conda"
         assert config.reuse_existing_virtualenvs is True
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -100,7 +100,21 @@ def test_main_long_form_args():
 
 def test_main_short_form_args(monkeypatch):
     monkeypatch.setattr(
-        sys, "argv", [sys.executable, "-f", "noxfile.py", "-s", "1", "2", "-db", "venv", "-fb", "conda", "-r"]
+        sys,
+        "argv",
+        [
+            sys.executable,
+            "-f",
+            "noxfile.py",
+            "-s",
+            "1",
+            "2",
+            "-db",
+            "venv",
+            "-fb",
+            "conda",
+            "-r",
+        ],
     )
     with mock.patch("nox.workflow.execute") as execute:
         execute.return_value = 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -70,6 +70,8 @@ def test_main_long_form_args():
         "--sessions",
         "1",
         "2",
+        "--venv_backend",
+        "venv",
         "--reuse-existing-virtualenvs",
         "--stop-on-first-error",
     ]
@@ -87,6 +89,7 @@ def test_main_long_form_args():
         assert config.noxfile == "noxfile.py"
         assert config.envdir.endswith(".other")
         assert config.sessions == ["1", "2"]
+        assert config.venv_backend == "venv"
         assert config.reuse_existing_virtualenvs is True
         assert config.stop_on_first_error is True
         assert config.posargs == []
@@ -94,7 +97,7 @@ def test_main_long_form_args():
 
 def test_main_short_form_args(monkeypatch):
     monkeypatch.setattr(
-        sys, "argv", [sys.executable, "-f", "noxfile.py", "-s", "1", "2", "-r"]
+        sys, "argv", [sys.executable, "-f", "noxfile.py", "-s", "1", "2", "-vb", "venv", "-r"]
     )
     with mock.patch("nox.workflow.execute") as execute:
         execute.return_value = 0
@@ -109,6 +112,7 @@ def test_main_short_form_args(monkeypatch):
         config = execute.call_args[1]["global_config"]
         assert config.noxfile == "noxfile.py"
         assert config.sessions == ["1", "2"]
+        assert config.venv_backend == "venv"
         assert config.reuse_existing_virtualenvs is True
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -120,7 +120,10 @@ def test_main_no_venv(monkeypatch, capsys):
         nox.__main__.main()
         stdout, stderr = capsys.readouterr()
         assert stdout == "Noms, cheddar so good!\n"
-        assert "Session snack is set to run with venv_backend='none', IGNORING its python" in stderr
+        assert (
+            "Session snack is set to run with venv_backend='none', IGNORING its python"
+            in stderr
+        )
         assert "Session snack(cheese='cheddar') was successful." in stderr
         sys_exit.assert_called_once_with(0)
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -18,7 +18,12 @@ from unittest import mock
 import nox
 import pytest
 from nox._decorators import Func
-from nox.manifest import KeywordLocals, Manifest, _null_session_func, WARN_PYTHONS_IGNORED
+from nox.manifest import (
+    KeywordLocals,
+    Manifest,
+    _null_session_func,
+    WARN_PYTHONS_IGNORED,
+)
 
 
 def create_mock_sessions():

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -18,7 +18,7 @@ from unittest import mock
 import nox
 import pytest
 from nox._decorators import Func
-from nox.manifest import KeywordLocals, Manifest, _null_session_func
+from nox.manifest import KeywordLocals, Manifest, _null_session_func, WARN_PYTHONS_IGNORED
 
 
 def create_mock_sessions():
@@ -351,3 +351,4 @@ def test_no_venv_backend_but_some_pythons():
 
     # check that the pythons were correctly removed (a log warning is also emitted)
     assert sessions[0].func.python is False
+    assert sessions[0].func.should_warn == {WARN_PYTHONS_IGNORED: ["3.7", "3.8"]}

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -23,14 +23,21 @@ from nox.manifest import KeywordLocals, Manifest, _null_session_func
 
 def create_mock_sessions():
     sessions = collections.OrderedDict()
-    sessions["foo"] = mock.Mock(spec=(), python=None)
-    sessions["bar"] = mock.Mock(spec=(), python=None)
+    sessions["foo"] = mock.Mock(spec=(), python=None, venv_backend=None)
+    sessions["bar"] = mock.Mock(spec=(), python=None, venv_backend=None)
     return sessions
+
+
+def create_mock_config():
+    cfg = mock.sentinel.CONFIG
+    cfg.force_venv_backend = None
+    cfg.default_venv_backend = None
+    return cfg
 
 
 def test_init():
     sessions = create_mock_sessions()
-    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+    manifest = Manifest(sessions, create_mock_config())
 
     # Assert that basic properties look correctly.
     assert len(manifest) == 2
@@ -40,7 +47,7 @@ def test_init():
 
 def test_contains():
     sessions = create_mock_sessions()
-    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+    manifest = Manifest(sessions, create_mock_config())
 
     # Establish that contains works pre-iteration.
     assert "foo" in manifest
@@ -60,7 +67,7 @@ def test_contains():
 
 def test_getitem():
     sessions = create_mock_sessions()
-    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+    manifest = Manifest(sessions, create_mock_config())
 
     # Establish that each session is present, and a made-up session
     # is not.
@@ -79,7 +86,7 @@ def test_getitem():
 
 def test_iteration():
     sessions = create_mock_sessions()
-    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+    manifest = Manifest(sessions, create_mock_config())
 
     # There should be two sessions in the queue.
     assert len(manifest._queue) == 2
@@ -109,7 +116,7 @@ def test_iteration():
 
 def test_len():
     sessions = create_mock_sessions()
-    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+    manifest = Manifest(sessions, create_mock_config())
     assert len(manifest) == 2
     for session in manifest:
         assert len(manifest) == 2
@@ -117,7 +124,7 @@ def test_len():
 
 def test_filter_by_name():
     sessions = create_mock_sessions()
-    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+    manifest = Manifest(sessions, create_mock_config())
     manifest.filter_by_name(("foo",))
     assert "foo" in manifest
     assert "bar" not in manifest
@@ -125,21 +132,21 @@ def test_filter_by_name():
 
 def test_filter_by_name_maintains_order():
     sessions = create_mock_sessions()
-    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+    manifest = Manifest(sessions, create_mock_config())
     manifest.filter_by_name(("bar", "foo"))
     assert [session.name for session in manifest] == ["bar", "foo"]
 
 
 def test_filter_by_name_not_found():
     sessions = create_mock_sessions()
-    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+    manifest = Manifest(sessions, create_mock_config())
     with pytest.raises(KeyError):
         manifest.filter_by_name(("baz",))
 
 
 def test_filter_by_python_interpreter():
     sessions = create_mock_sessions()
-    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+    manifest = Manifest(sessions, create_mock_config())
     manifest["foo"].func.python = "3.8"
     manifest["bar"].func.python = "3.7"
     manifest.filter_by_python_interpreter(("3.8",))
@@ -149,7 +156,7 @@ def test_filter_by_python_interpreter():
 
 def test_filter_by_keyword():
     sessions = create_mock_sessions()
-    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+    manifest = Manifest(sessions, create_mock_config())
     assert len(manifest) == 2
     manifest.filter_by_keywords("foo or bar")
     assert len(manifest) == 2
@@ -159,7 +166,7 @@ def test_filter_by_keyword():
 
 def test_list_all_sessions_with_filter():
     sessions = create_mock_sessions()
-    manifest = Manifest(sessions, mock.sentinel.CONFIG)
+    manifest = Manifest(sessions, create_mock_config())
     assert len(manifest) == 2
     manifest.filter_by_keywords("foo")
     assert len(manifest) == 1
@@ -171,15 +178,15 @@ def test_list_all_sessions_with_filter():
 
 
 def test_add_session_plain():
-    manifest = Manifest({}, mock.sentinel.CONFIG)
-    session_func = mock.Mock(spec=(), python=None)
+    manifest = Manifest({}, create_mock_config())
+    session_func = mock.Mock(spec=(), python=None, venv_backend=None)
     for session in manifest.make_session("my_session", session_func):
         manifest.add_session(session)
     assert len(manifest) == 1
 
 
 def test_add_session_multiple_pythons():
-    manifest = Manifest({}, mock.sentinel.CONFIG)
+    manifest = Manifest({}, create_mock_config())
 
     def session_func():
         pass
@@ -192,7 +199,7 @@ def test_add_session_multiple_pythons():
 
 
 def test_add_session_parametrized():
-    manifest = Manifest({}, mock.sentinel.CONFIG)
+    manifest = Manifest({}, create_mock_config())
 
     # Define a session with parameters.
     @nox.parametrize("param", ("a", "b", "c"))
@@ -208,7 +215,7 @@ def test_add_session_parametrized():
 
 
 def test_add_session_parametrized_multiple_pythons():
-    manifest = Manifest({}, mock.sentinel.CONFIG)
+    manifest = Manifest({}, create_mock_config())
 
     # Define a session with parameters.
     @nox.parametrize("param", ("a", "b"))
@@ -224,7 +231,7 @@ def test_add_session_parametrized_multiple_pythons():
 
 
 def test_add_session_parametrized_noop():
-    manifest = Manifest({}, mock.sentinel.CONFIG)
+    manifest = Manifest({}, create_mock_config())
 
     # Define a session without any parameters.
     @nox.parametrize("param", ())
@@ -232,6 +239,7 @@ def test_add_session_parametrized_noop():
         pass
 
     my_session.python = None
+    my_session.venv_backend = None
 
     # Add the session to the manifest.
     for session in manifest.make_session("my_session", my_session):
@@ -244,18 +252,20 @@ def test_add_session_parametrized_noop():
 
 
 def test_notify():
-    manifest = Manifest({}, mock.sentinel.CONFIG)
+    manifest = Manifest({}, create_mock_config())
 
     # Define a session.
     def my_session(session):
         pass
 
     my_session.python = None
+    my_session.venv_backend = None
 
     def notified(session):
         pass
 
     notified.python = None
+    notified.venv_backend = None
 
     # Add the sessions to the manifest.
     for session in manifest.make_session("my_session", my_session):
@@ -274,13 +284,14 @@ def test_notify():
 
 
 def test_notify_noop():
-    manifest = Manifest({}, mock.sentinel.CONFIG)
+    manifest = Manifest({}, create_mock_config())
 
     # Define a session and add it to the manifest.
     def my_session(session):
         pass
 
     my_session.python = None
+    my_session.venv_backend = None
 
     for session in manifest.make_session("my_session", my_session):
         manifest.add_session(session)
@@ -293,14 +304,14 @@ def test_notify_noop():
 
 
 def test_notify_error():
-    manifest = Manifest({}, mock.sentinel.CONFIG)
+    manifest = Manifest({}, create_mock_config())
     with pytest.raises(ValueError):
         manifest.notify("does_not_exist")
 
 
 def test_add_session_idempotent():
-    manifest = Manifest({}, mock.sentinel.CONFIG)
-    session_func = mock.Mock(spec=(), python=None)
+    manifest = Manifest({}, create_mock_config())
+    session_func = mock.Mock(spec=(), python=None, venv_backend=None)
     for session in manifest.make_session("my_session", session_func):
         manifest.add_session(session)
         manifest.add_session(session)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -333,3 +333,20 @@ def test_keyword_locals_iter():
     values = ["foo", "bar"]
     kw = KeywordLocals(values)
     assert list(kw) == values
+
+
+def test_no_venv_backend_but_some_pythons():
+    manifest = Manifest({}, create_mock_config())
+
+    # Define a session and add it to the manifest.
+    def my_session(session):
+        pass
+
+    # the session sets "no venv backend" but declares some pythons
+    my_session.python = ["3.7", "3.8"]
+    my_session.venv_backend = "none"
+
+    sessions = manifest.make_session("my_session", my_session)
+
+    # check that the pythons were correctly removed (a log warning is also emitted)
+    assert sessions[0].func.python is False

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -345,6 +345,7 @@ def test_no_venv_backend_but_some_pythons():
     # the session sets "no venv backend" but declares some pythons
     my_session.python = ["3.7", "3.8"]
     my_session.venv_backend = "none"
+    my_session.should_warn = dict()
 
     sessions = manifest.make_session("my_session", my_session)
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -246,6 +246,7 @@ class TestSession:
     def test_conda_install_bad_args(self):
         session, runner = self.make_session_and_runner()
         runner.venv = mock.create_autospec(nox.virtualenv.CondaEnv)
+        runner.venv.location = "dummy"
 
         with pytest.raises(ValueError, match="arg"):
             session.conda_install()

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -33,6 +33,7 @@ def session_func():
 
 
 session_func.python = None
+session_func.venv_backend = None
 
 
 def session_func_with_python():
@@ -40,6 +41,7 @@ def session_func_with_python():
 
 
 session_func_with_python.python = "3.8"
+session_func_with_python.venv_backend = None
 
 
 def test_load_nox_module():

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -34,6 +34,7 @@ def session_func():
 
 session_func.python = None
 session_func.venv_backend = None
+session_func.should_warn = dict()
 
 
 def session_func_with_python():
@@ -202,6 +203,8 @@ def test_run_manifest():
         mock_session.execute.return_value = sessions.Result(
             session=mock_session, status=sessions.Status.SUCCESS
         )
+        # we need the should_warn attribute, add some func
+        mock_session.func = session_func
 
     # Run the manifest.
     results = tasks.run_manifest(manifest, global_config=config)
@@ -230,6 +233,8 @@ def test_run_manifest_abort_on_first_failure():
         mock_session.execute.return_value = sessions.Result(
             session=mock_session, status=sessions.Status.FAILED
         )
+        # we need the should_warn attribute, add some func
+        mock_session.func = session_func
 
     # Run the manifest.
     results = tasks.run_manifest(manifest, global_config=config)


### PR DESCRIPTION
Changelog (let me know if I should commit it in the changelog file):

 - New global option `nox.options.default_venv_backend` to set the default backend. Fixes #315 
 - New global option `nox.options.force_venv_backend` to temporarily force the backend. The commandline version of this option will probably be used more frequently than the noxfile one, but thanks to the great generic option mechanism built in nox, I got both for the same price :) . Fixes #317
 - Added possibility to declare a "no backend / passthrough" venv with `venv_backend='none'` (or to force it temporarily with the `--no-venv` cli option, equivalent to `--force-venv-backend none`, see above). Fixes #301
 - Now `install` and `conda_install` work when there is no venv backend (or python=False). Previously a `ValueError` was raised. Fixes #318

I updated the doc accordingly.