### PR TITLE
Do not merge command-line options and nox.options in place

### DIFF
--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -304,13 +304,16 @@ class OptionSet:
         self, command_args: Namespace, noxfile_args: Namespace
     ) -> None:
         """Merges the command-line options with the noxfile options."""
+        command_args_copy = Namespace(**vars(command_args))
         for name, option in self.options.items():
             if option.merge_func:
                 setattr(
-                    command_args, name, option.merge_func(command_args, noxfile_args)
+                    command_args,
+                    name,
+                    option.merge_func(command_args_copy, noxfile_args),
                 )
             elif option.noxfile:
-                value = getattr(command_args, name, None) or getattr(
+                value = getattr(command_args_copy, name, None) or getattr(
                     noxfile_args, name, None
                 )
                 setattr(command_args, name, value)


### PR DESCRIPTION
Fixes #356 

When merging options specified in the noxfile and on the command-line, do not use the output parameter `command_args` as the input for the merge. Instead, copy `command_args` initially and pass the copy to the merge functions.

Merge functions such as `_session_filters_merge_func` inspect `command_args` to see if other options have been specified on the command-line. When the options are merged in place, this check produces false positives.

For example, `nox.options.sessions` is copied into `command_args` as a part of the merge. So it will appear to have been specified on the command-line when merging `nox.options.pythons`, causing the latter to be ignored.
