### PR TITLE
Decouple merging of --python with nox.options from --sessions and --keywords

### DIFF
--- a/nox/_options.py
+++ b/nox/_options.py
@@ -44,18 +44,18 @@ options.add_groups(
 def _session_filters_merge_func(
     key: str, command_args: argparse.Namespace, noxfile_args: argparse.Namespace
 ) -> List[str]:
-    """Only return the Noxfile value for sessions/pythons/keywords if neither sessions,
-    pythons or keywords are specified on the command-line.
+    """Only return the Noxfile value for sessions/keywords if neither sessions
+    or keywords are specified on the command-line.
 
     Args:
-        key (str): This function is used for the "sessions", "pythons" and "keywords"
+        key (str): This function is used for both the "sessions" and "keywords"
             options, this allows using ``funtools.partial`` to pass the
             same function for both options.
         command_args (_option_set.Namespace): The options specified on the
             command-line.
-        noxfile_args (_option_set.Namespace): The options specified in the
+        noxfile_Args (_option_set.Namespace): The options specified in the
             Noxfile."""
-    if not any((command_args.sessions, command_args.pythons, command_args.keywords)):
+    if not command_args.sessions and not command_args.keywords:
         return getattr(noxfile_args, key)
     return getattr(command_args, key)
 

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -41,7 +41,7 @@ options.add_groups(
 )
 
 
-def _session_filters_merge_func(
+def _sessions_and_keywords_merge_func(
     key: str, command_args: argparse.Namespace, noxfile_args: argparse.Namespace
 ) -> List[str]:
     """Only return the Noxfile value for sessions/keywords if neither sessions
@@ -221,7 +221,7 @@ options.add_options(
         "--session",
         group=options.groups["primary"],
         noxfile=True,
-        merge_func=functools.partial(_session_filters_merge_func, "sessions"),
+        merge_func=functools.partial(_sessions_and_keywords_merge_func, "sessions"),
         nargs="*",
         default=_sessions_default,
         help="Which sessions to run. By default, all sessions will run.",
@@ -243,7 +243,7 @@ options.add_options(
         "--keywords",
         group=options.groups["primary"],
         noxfile=True,
-        merge_func=functools.partial(_session_filters_merge_func, "keywords"),
+        merge_func=functools.partial(_sessions_and_keywords_merge_func, "keywords"),
         help="Only run sessions that match the given expression.",
     ),
     _option_set.Option(

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -234,7 +234,6 @@ options.add_options(
         "--python",
         group=options.groups["primary"],
         noxfile=True,
-        merge_func=functools.partial(_session_filters_merge_func, "pythons"),
         nargs="*",
         help="Only run sessions that use the given python interpreter versions.",
     ),

--- a/tests/resources/noxfile_options_pythons.py
+++ b/tests/resources/noxfile_options_pythons.py
@@ -1,0 +1,28 @@
+# Copyright 2020 Alethea Katherine Flowers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nox
+
+nox.options.sessions = ["{default_session}"]
+nox.options.pythons = ["{default_python}"]
+
+
+@nox.session(python=["{default_python}", "{alternate_python}"])
+def test(session):
+    pass
+
+
+@nox.session(python=["{default_python}", "{alternate_python}"])
+def launch_rocket(session):
+    pass

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -500,6 +500,33 @@ def test_main_noxfile_options_with_pythons_override(
                 assert line not in stderr
 
 
+def test_main_noxfile_options_with_sessions_override(
+    capsys, monkeypatch, generate_noxfile_options_pythons
+):
+    noxfile = generate_noxfile_options_pythons(
+        default_session="test",
+        default_python=python_current_version,
+        alternate_python=python_next_version,
+    )
+
+    monkeypatch.setattr(
+        sys, "argv", ["nox", "--noxfile", noxfile, "--session", "launch_rocket"]
+    )
+
+    with mock.patch("sys.exit") as sys_exit:
+        nox.__main__.main()
+        _, stderr = capsys.readouterr()
+        sys_exit.assert_called_once_with(0)
+
+    for python_version in [python_current_version, python_next_version]:
+        for session in ["test", "launch_rocket"]:
+            line = "Running session {}-{}".format(session, python_version)
+            if session == "launch_rocket" and python_version == python_current_version:
+                assert line in stderr
+            else:
+                assert line not in stderr
+
+
 @pytest.mark.parametrize(("isatty_value", "expected"), [(True, True), (False, False)])
 def test_main_color_from_isatty(monkeypatch, isatty_value, expected):
     monkeypatch.setattr(sys, "argv", [sys.executable])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,6 +14,7 @@
 
 import os
 import sys
+from pathlib import Path
 from unittest import mock
 
 import contexter
@@ -442,6 +443,30 @@ def test_main_noxfile_options_sessions(monkeypatch):
         # Verify that the config looks correct.
         config = honor_list_request.call_args[1]["global_config"]
         assert config.sessions == ["test"]
+
+
+@pytest.fixture
+def generate_noxfile_options_pythons(tmp_path):
+    """Generate noxfile.py with test and launch_rocket sessions.
+
+    The sessions are defined for both the default and alternate Python versions.
+    The ``default_session`` and ``default_python`` parameters determine what
+    goes into ``nox.options.sessions`` and ``nox.options.pythons``, respectively.
+    """
+
+    def generate_noxfile(default_session, default_python, alternate_python):
+        path = Path(RESOURCES) / "noxfile_options_pythons.py"
+        text = path.read_text()
+        text = text.format(
+            default_session=default_session,
+            default_python=default_python,
+            alternate_python=alternate_python,
+        )
+        path = tmp_path / "noxfile.py"
+        path.write_text(text)
+        return str(path)
+
+    return generate_noxfile
 
 
 @pytest.mark.parametrize(("isatty_value", "expected"), [(True, True), (False, False)])


### PR DESCRIPTION
Closes #358 

This PR is a follow-up to #357, and contains the following additional changes:

**1. Do not ignore nox.options.pythons when --{sessions,keywords} passed**

Declare the `--python` option without a custom merge function, i.e. omit the `merge_func` parameter. As a result, `nox.options.pythons` will no longer be ignored when `--sessions` or `--keywords` are passed.

**2. Do not ignore nox.options.{sessions,keywords} when --pythons passed**

Revert `_session_filters_merge_func` to the state before `--pythons` was introduced. This means that it will only check if `--sessions` or `--keywords` were specified on the command-line. As a result, the `nox.options.sessions` and `nox.options.keywords` settings will no longer be ignored when `--pythons` is passed.