### PR TITLE
Refactor pip as python -m pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,8 @@ before_install:
   - conda update --yes conda
   - export SETUPTOOLS_USE_DISTUTILS=stdlib
 install:
-  - pip install --upgrade pip setuptools
-  - pip install .
+  - python -m pip install --upgrade pip setuptools
+  - python -m pip install .
 script: nox --non-interactive --session "$NOXSESSION"
 deploy:
   provider: pypi

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -237,10 +237,10 @@ When you run ``nox``, it will create a two distinct sessions:
 
     $ nox
     nox > Running session tests(django='1.9')
-    nox > pip install django==1.9
+    nox > python -m pip install django==1.9
     ...
     nox > Running session tests(django='2.0')
-    nox > pip install django==2.0
+    nox > python -m pip install django==2.0
 
 
 :func:`nox.parametrize` has an interface and usage intentionally similar to `pytest's parametrize <https://pytest.org/latest/parametrize.html#_pytest.python.Metafunc.parametrize>`_.

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -249,8 +249,8 @@ Would run both ``install`` commands, but skip the ``run`` command:
 
     nox > Running session tests
     nox > Creating virtualenv using python3.7 in ./.nox/tests
-    nox > pip install pytest
-    nox > pip install .
+    nox > python -m pip install pytest
+    nox > python -m pip install .
     nox > Skipping pytest run, as --install-only is set.
     nox > Session tests was successful.
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -423,7 +423,7 @@ class Session:
         if "silent" not in kwargs:
             kwargs["silent"] = True
 
-        self._run("pip", "install", *args, external="error", **kwargs)
+        self._run("python", "-m", "pip", "install", *args, external="error", **kwargs)
 
     def notify(self, target: "Union[str, SessionRunner]") -> None:
         """Place the given session at the end of the queue.

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -192,7 +192,7 @@ class TestSession:
             session.run("spam", "eggs")
 
         run.assert_called_once_with(
-            ("pip", "install", "spam"),
+            ("python", "-m", "pip", "install", "spam"),
             env=mock.ANY,
             external=mock.ANY,
             paths=mock.ANY,
@@ -445,7 +445,14 @@ class TestSession:
         with mock.patch.object(session, "_run", autospec=True) as run:
             session.install("requests", "urllib3")
             run.assert_called_once_with(
-                "pip", "install", "requests", "urllib3", silent=True, external="error"
+                "python",
+                "-m",
+                "pip",
+                "install",
+                "requests",
+                "urllib3",
+                silent=True,
+                external="error",
             )
 
     def test_install_non_default_kwargs(self):
@@ -467,7 +474,14 @@ class TestSession:
         with mock.patch.object(session, "_run", autospec=True) as run:
             session.install("requests", "urllib3", silent=False)
             run.assert_called_once_with(
-                "pip", "install", "requests", "urllib3", silent=False, external="error"
+                "python",
+                "-m",
+                "pip",
+                "install",
+                "requests",
+                "urllib3",
+                silent=False,
+                external="error",
             )
 
     def test_notify(self):


### PR DESCRIPTION
Closes #262 
- Refactored `pip` as `python -m pip`. Since It is a good practice.

@theacodes  Please review 😃 
