### PR TITLE
Add isort check to lint session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -80,7 +80,7 @@ def blacken(session):
 
 @nox.session(python="3.8")
 def lint(session):
-    session.install("flake8==3.7.8", "black==19.3b0", "mypy==0.720")
+    session.install("flake8==3.7.8", "black==19.3b0", "isort==4.3.21", "mypy==0.720")
     session.run(
         "mypy",
         "--disallow-untyped-defs",
@@ -90,6 +90,7 @@ def lint(session):
     )
     files = ["nox", "tests", "noxfile.py", "setup.py"]
     session.run("black", "--check", *files)
+    session.run("isort", "--check", "--recursive", *files)
     session.run("flake8", "nox", *files)
 
 


### PR DESCRIPTION
This came up in the context of #364:

> Thanks! I think we can add this check in the lint step (`isort --check`)
> 
> https://github.com/theacodes/nox/blob/495b23ff690049e8f3d25f3d29c06458da2ee274/noxfile.py#L82
> 
> Compatible settings are in https://github.com/psf/black/blob/master/docs/compatible_configs.md#isort
> 
> That can be done in another PR of course, CI failure looks unrelated

@stsewd Nox's `.isort.cfg` contains all of the compatible configuration settings you linked to, with the exception of `ensure_newline_before_comments = True`. I did not bother to add that setting to the configuration file because isort 5 has a black profile, rendering manual configuration unnecessary once we upgrade.