### PR TITLE
Support double-digit minor version in `python` keyword

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -330,7 +330,7 @@ class VirtualEnv(ProcessEnv):
 
         # If this is just a X, X.Y, or X.Y.Z string, extract just the X / X.Y
         # part and add Python to the front of it.
-        match = re.match(r"^(?P<xy_ver>\d(\.\d)?)(\.\d+)?$", self.interpreter)
+        match = re.match(r"^(?P<xy_ver>\d(\.\d+)?)(\.\d+)?$", self.interpreter)
         if match:
             xy_version = match.group("xy_ver")
             cleaned_interpreter = "python{}".format(xy_version)
@@ -347,7 +347,7 @@ class VirtualEnv(ProcessEnv):
             raise self._resolved
 
         # Allow versions of the form ``X.Y-32`` for Windows.
-        match = re.match(r"^\d\.\d-32?$", cleaned_interpreter)
+        match = re.match(r"^\d\.\d+-32?$", cleaned_interpreter)
         if match:
             # preserve the "-32" suffix, as the Python launcher expects
             # it.

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -330,6 +330,7 @@ def test__resolved_interpreter_none(make_one):
         ("3", "python3"),
         ("3.6", "python3.6"),
         ("3.6.2", "python3.6"),
+        ("3.10", "python3.10"),
         ("2.7.15", "python2.7"),
     ],
 )


### PR DESCRIPTION
This fixes an issue where "3.10" is resolved as "python3", as demonstrated by the test case.

<details>
<summary>
Test failure
</summary>

```
==================================================================================== FAILURES ====================================================================================
_______________________________________________________ test__resolved_interpreter_numerical_non_windows[3.10-python3.10] ________________________________________________________

sysfind = <MagicMock name='sysfind' id='4339276912'>, make_one = <function make_one.<locals>.factory at 0x102a6e790>, input_ = '3.10', expected = 'python3.10'

    @pytest.mark.parametrize(
        ["input_", "expected"],
        [
            ("3", "python3"),
            ("3.6", "python3.6"),
            ("3.6.2", "python3.6"),
            ("3.10", "python3.10"),
            ("2.7.15", "python2.7"),
        ],
    )
    @mock.patch("nox.virtualenv._SYSTEM", new="Linux")
    @mock.patch.object(py.path.local, "sysfind", return_value=True)
    def test__resolved_interpreter_numerical_non_windows(
        sysfind, make_one, input_, expected
    ):
        venv, _ = make_one(interpreter=input_)

>       assert venv._resolved_interpreter == expected
E       AssertionError: assert 'python3' == 'python3.10'
E         - python3.10
E         ?        ---
E         + python3

.../nox/tests/test_virtualenv.py:344: AssertionError


============================================================================ short test summary info =============================================================================
FAILED tests/test_virtualenv.py::test__resolved_interpreter_numerical_non_windows[3.10-python3.10] - AssertionError: assert 'python3' == 'python3.10'
============================================================== 1 failed, 266 passed, 2 skipped, 1 xfailed in 20.22s ==============================================================
```

</details>


I'm keeping the scope of this PR deliberately restricted to the fix.

Some other things we'd likely want for Python 3.10 support:

- Add 3.10 to Nox's own Nox sessions
- Add trove classifier
- Add Python 3.10 to Appveyor CI
- Add Python 3.10 to Travis CI
- Update Contributor Guide
- Update documentation (config.rst)
- More?
