### PR TITLE
Allow passing PathLike types to Session.chdir()

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -184,7 +184,7 @@ class Session:
         """Returns True if Nox is being run in an interactive session or False otherwise."""
         return not self._runner.global_config.non_interactive and sys.stdin.isatty()
 
-    def chdir(self, dir: str) -> None:
+    def chdir(self, dir: Union[str, os.PathLike]) -> None:
         """Change the current working directory."""
         self.log("cd {}".format(dir))
         os.chdir(dir)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -18,6 +18,7 @@ import operator
 import os
 import sys
 import tempfile
+from pathlib import Path
 from unittest import mock
 
 import nox.command
@@ -147,6 +148,17 @@ class TestSession:
         session, _ = self.make_session_and_runner()
 
         session.chdir(cdto)
+
+        assert os.getcwd() == cdto
+        os.chdir(current_cwd)
+
+    def test_chdir_pathlib(self, tmpdir):
+        cdto = str(tmpdir.join("cdbby").ensure(dir=True))
+        current_cwd = os.getcwd()
+
+        session, _ = self.make_session_and_runner()
+
+        session.chdir(Path(cdto))
 
         assert os.getcwd() == cdto
         os.chdir(current_cwd)


### PR DESCRIPTION
os.chdir() has supported PathLib since Python 3.6.

Discovered while adding types pip's noxfile.py:
https://github.com/pypa/pip/pull/9411