### PR TITLE
Define the location attribute on base class ProcessEnv

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -43,6 +43,8 @@ class InterpreterNotFound(OSError):
 class ProcessEnv:
     """A environment with a 'bin' directory and a set of 'env' vars."""
 
+    location: str
+
     # Does this environment provide any process isolation?
     is_sandboxed = False
 


### PR DESCRIPTION
Fixes errors when running mypy on a project's noxfile.py:

    noxfile.py:42: error: "ProcessEnv" has no attribute "location"

Discovered while adding types pip's noxfile.py:
pypa/pip#9411