### PR TITLE
Make ProcessEnv.bin always return a str

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -167,10 +167,12 @@ class Session:
         return self.virtualenv.bin_paths
 
     @property
-    def bin(self) -> Optional[str]:
+    def bin(self) -> str:
         """The first bin directory for the virtualenv."""
         paths = self.bin_paths
-        return paths[0] if paths is not None else None
+        if paths is None:
+            raise ValueError("The environment does not have a bin directory.")
+        return paths[0]
 
     def create_tmp(self) -> str:
         """Create, and return, a temporary directory."""

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -69,10 +69,12 @@ class ProcessEnv:
         return self._bin_paths
 
     @property
-    def bin(self) -> Optional[str]:
+    def bin(self) -> str:
         """The first bin directory for the virtualenv."""
         paths = self.bin_paths
-        return paths[0] if paths is not None else None
+        if paths is None:
+            raise ValueError("The environment does not have a bin directory.")
+        return paths[0]
 
     def create(self) -> bool:
         raise NotImplementedError("ProcessEnv.create should be overwritten in subclass")

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -108,7 +108,10 @@ class TestSession:
         session, runner = self.make_session_and_runner()
 
         runner.venv.bin_paths = None
-        assert session.bin is None
+        with pytest.raises(
+            ValueError, match=r"^The environment does not have a bin directory\.$"
+        ):
+            session.bin
         assert session.bin_paths is None
 
     def test_virtualenv_as_none(self):

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -121,9 +121,16 @@ def patch_sysfind(make_mocked_interpreter_path):
 def test_process_env_constructor():
     penv = nox.virtualenv.ProcessEnv()
     assert not penv.bin_paths
+    with pytest.raises(
+        ValueError, match=r"^The environment does not have a bin directory\.$"
+    ):
+        penv.bin
 
     penv = nox.virtualenv.ProcessEnv(env={"SIGIL": "123"})
     assert penv.env["SIGIL"] == "123"
+
+    penv = nox.virtualenv.ProcessEnv(bin_paths=["/bin"])
+    assert penv.bin == "/bin"
 
 
 def test_process_env_create():


### PR DESCRIPTION
The property now never returns None. This simplifies user code containing
types that already knows a bin directory must exist. It avoids the need
to pepper calling code with:

    assert session.bin is not None

Or

    # type: ignore

For example, in pip:
https://github.com/pypa/pip/blob/062f0e54d99f58e53be36be5a45adad89e2429fb/tools/automation/release/__init__.py#L29

A noxfile that tries to access a bin directory that doesn't exist will
now raise an exception.