### PR TITLE
Decode popen output using the system locale if UTF-8 decoding fails.

### DIFF
--- a/nox/popen.py
+++ b/nox/popen.py
@@ -26,24 +26,20 @@ def decode_output(output: bytes) -> str:
     :return: decoded string
     """
     decoded_output = ""
-    encodings = {
-        "utf8",
-        sys.stdout.encoding or "utf8",
-        sys.getdefaultencoding() or "utf8",
-        locale.getpreferredencoding() or "utf8",
-    }
 
-    for idx, encoding in enumerate(encodings):
-        try:
-            print(encoding)
-            decoded_output = output.decode(encoding)
-        except UnicodeDecodeError as exc:
-            if idx + 1 < len(encodings):
-                continue
-            exc.encoding = str(encodings).replace("'", "")
+    try:
+        decoded_output = output.decode("utf8")
+    except UnicodeDecodeError:
+        nd_enc = locale.getpreferredencoding()
+        if nd_enc.casefold() in ("utf8", "utf-8"):
             raise
-        else:
-            break
+
+        try:
+            decoded_output = output.decode("utf8")
+        except UnicodeDecodeError as exc:
+            exc.encoding = f"[utf-8, {nd_enc}]"
+            raise
+            
 
     return decoded_output
 

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -30,14 +30,14 @@ def decode_output(output: bytes) -> str:
     try:
         decoded_output = output.decode("utf8")
     except UnicodeDecodeError:
-        nd_enc = locale.getpreferredencoding()
-        if nd_enc.casefold() in ("utf8", "utf-8"):
+        second_encoding = locale.getpreferredencoding()
+        if second_encoding.casefold() in ("utf8", "utf-8"):
             raise
 
         try:
-            decoded_output = output.decode("utf8")
+            decoded_output = output.decode(second_encoding)
         except UnicodeDecodeError as exc:
-            exc.encoding = f"[utf-8, {nd_enc}]"
+            exc.encoding = f"[utf-8, {second_encoding}]"
             raise
 
     return decoded_output

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -28,7 +28,7 @@ def decode_output(output: bytes) -> str:
     decoded_output = ""
 
     try:
-        decoded_output = output.decode("utf8")
+        decoded_output = output.decode("utf-8")
     except UnicodeDecodeError:
         second_encoding = locale.getpreferredencoding()
         if second_encoding.casefold() in ("utf8", "utf-8"):

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -25,22 +25,14 @@ def decode_output(output: bytes) -> str:
     :raises UnicodeDecodeError: if all encodings fail
     :return: decoded string
     """
-    decoded_output = ""
-
     try:
-        decoded_output = output.decode("utf-8")
+        return output.decode("utf-8")
     except UnicodeDecodeError:
         second_encoding = locale.getpreferredencoding()
         if second_encoding.casefold() in ("utf8", "utf-8"):
             raise
 
-        try:
-            decoded_output = output.decode(second_encoding)
-        except UnicodeDecodeError as exc:
-            exc.encoding = f"[utf-8, {second_encoding}]"
-            raise
-
-    return decoded_output
+        return output.decode(second_encoding)
 
 
 def popen(

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -39,7 +39,6 @@ def decode_output(output: bytes) -> str:
         except UnicodeDecodeError as exc:
             exc.encoding = f"[utf-8, {nd_enc}]"
             raise
-            
 
     return decoded_output
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -314,15 +314,17 @@ def test_output_decoding_utf8_only_fail(monkeypatch: pytest.MonkeyPatch) -> None
 
     with pytest.raises(UnicodeDecodeError) as exc:
         nox.popen.decode_output(b"\x95")
-    
+
     assert exc.value.encoding == "utf-8"
 
 
-def test_output_decoding_utf8_fail_cp1252_success(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_output_decoding_utf8_fail_cp1252_success(
+    monkeypatch: pytest.MonkeyPatch
+) -> None:
     monkeypatch.setattr(nox.popen.locale, "getpreferredencoding", lambda: "cp1252")
 
     result = nox.popen.decode_output(b"\x95")
-    
+
     assert result == "•"  # U+2022
 
 
@@ -330,6 +332,6 @@ def test_output_decoding_both_fail(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(nox.popen.locale, "getpreferredencoding", lambda: "ascii")
 
     with pytest.raises(UnicodeDecodeError) as exc:
-            nox.popen.decode_output(b"\x95")
-        
+        nox.popen.decode_output(b"\x95")
+
     assert exc.value.encoding == "[utf-8, ascii]"

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -334,4 +334,4 @@ def test_output_decoding_both_fail(monkeypatch: pytest.MonkeyPatch) -> None:
     with pytest.raises(UnicodeDecodeError) as exc:
         nox.popen.decode_output(b"\x95")
 
-    assert exc.value.encoding == "[utf-8, ascii]"
+    assert exc.value.encoding == "ascii"


### PR DESCRIPTION
Based on my comments in the issue #309 I created a decoding wrapper function. As `utf8` is the python default I kept it hard coded as first choice of the encodings to try. If `utf8` fails `sys.stdout.encoding`, `sys.getdefaultencoding()` and `locale.getpreferredencoding()` (in this order) deliver possible other encodings to try. If all decoding attempts fail the `UnicodeDecodeError` exception is risen.

I'm open for other orders of the encoding sources.

If this fix is well received, I will add the missing tests and fix the broken ones if there are any.

fixes #309