### PR TITLE
Add `Session.name`

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -138,6 +138,11 @@ class Session:
         return {"_runner": self._runner}
 
     @property
+    def name(self) -> str:
+        """The name of this session."""
+        return self._runner.friendly_name
+
+    @property
     def env(self) -> dict:
         """A dictionary of environment variables to pass into all commands."""
         return self.virtualenv.env

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -98,6 +98,7 @@ class TestSession:
     def test_properties(self):
         session, runner = self.make_session_and_runner()
 
+        assert session.name is runner.friendly_name
         assert session.env is runner.venv.env
         assert session.posargs is runner.global_config.posargs
         assert session.virtualenv is runner.venv


### PR DESCRIPTION
Being able to know what session you are in is useful for a variety of reasons. One of which is to be able to name artifacts in a way that is traceable back to the session, such as with [code coverage reports](https://stackoverflow.com/q/66170792/1485877). Right now, the only solution is to dig down to `session._runner.friendly_name`:

```python
import nox


@nox.session(python=['3.6', '3.7', '3.8', '3.9'])
def test(session):
    session.install('.')
    session.install('pytest', 'pytest-cov')
    session.env['COVERAGE_FILE'] = f'.coverage.{session._runner.friendly_name}'
    session.run('python', '-m', 'pytest', '--cov', 'tests/')
```

This PR exposes that private attribute via a public property:

```python
import nox


@nox.session(python=['3.6', '3.7', '3.8', '3.9'])
def test(session):
    session.install('.')
    session.install('pytest', 'pytest-cov')
    session.env['COVERAGE_FILE'] = f'.coverage.{session.name}'
    session.run('python', '-m', 'pytest', '--cov', 'tests/')
```