### PR TITLE
Add nox.needs_version to specify Nox version requirements

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -339,7 +339,6 @@ Produces these sessions when running ``nox --list``:
     * tests(mysql, new)
 
 
-
 The session object
 ------------------
 
@@ -394,3 +393,28 @@ The following options can be specified in the Noxfile:
 
 
 When invoking ``nox``, any options specified on the command line take precedence over the options specified in the Noxfile. If either ``--sessions`` or ``--keywords`` is specified on the command line, *both* options specified in the Noxfile will be ignored.
+
+
+Nox version requirements
+------------------------
+
+Nox version requirements can be specified in your ``noxfile.py`` by setting
+``nox.needs_version``. If the Nox version does not satisfy the requirements, Nox
+exits with a friendly error message. For example:
+
+.. code-block:: python
+
+    import nox
+
+    nox.needs_version = ">=2019.5.30"
+
+    @nox.session(name="test")  # name argument was added in 2019.5.30
+    def pytest(session):
+        session.run("pytest")
+
+
+Any of the version specifiers defined in `PEP 440`_ can be used. If you assign a
+string literal like in the example above, Nox is able to check the version
+without importing the Noxfile.
+
+.. _PEP 440: https://www.python.org/dev/peps/pep-0440/

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -398,7 +398,7 @@ When invoking ``nox``, any options specified on the command line take precedence
 Nox version requirements
 ------------------------
 
-Nox version requirements can be specified in your ``noxfile.py`` by setting
+Nox version requirements can be specified in your Noxfile by setting
 ``nox.needs_version``. If the Nox version does not satisfy the requirements, Nox
 exits with a friendly error message. For example:
 
@@ -412,9 +412,10 @@ exits with a friendly error message. For example:
     def pytest(session):
         session.run("pytest")
 
+Any of the version specifiers defined in `PEP 440`_ can be used.
 
-Any of the version specifiers defined in `PEP 440`_ can be used. If you assign a
-string literal like in the example above, Nox is able to check the version
-without importing the Noxfile.
+**Important**: Version requirements *must* be specified as a string literal,
+using a simple assignment to ``nox.needs_version`` at the module level. This
+allows Nox to check the version without importing the Noxfile.
 
 .. _PEP 440: https://www.python.org/dev/peps/pep-0440/

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -414,8 +414,8 @@ exits with a friendly error message. For example:
 
 Any of the version specifiers defined in `PEP 440`_ can be used.
 
-**Important**: Version requirements *must* be specified as a string literal,
-using a simple assignment to ``nox.needs_version`` at the module level. This
-allows Nox to check the version without importing the Noxfile.
+.. warning:: Version requirements *must* be specified as a string literal,
+    using a simple assignment to ``nox.needs_version`` at the module level. This
+    allows Nox to check the version without importing the Noxfile.
 
 .. _PEP 440: https://www.python.org/dev/peps/pep-0440/

--- a/nox/__init__.py
+++ b/nox/__init__.py
@@ -12,10 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from typing import Optional
+
 from nox._options import noxfile_options as options
 from nox._parametrize import Param as param
 from nox._parametrize import parametrize_decorator as parametrize
 from nox.registry import session_decorator as session
 from nox.sessions import Session
 
-__all__ = ["parametrize", "param", "session", "options", "Session"]
+needs_version: Optional[str] = None
+
+__all__ = ["needs_version", "parametrize", "param", "session", "options", "Session"]

--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -22,12 +22,8 @@ control to :meth:``nox.workflow.execute``.
 import sys
 
 from nox import _options, tasks, workflow
+from nox._version import get_nox_version
 from nox.logger import setup_logging
-
-try:
-    import importlib.metadata as metadata
-except ImportError:  # pragma: no cover
-    import importlib_metadata as metadata
 
 
 def main() -> None:
@@ -38,7 +34,7 @@ def main() -> None:
         return
 
     if args.version:
-        print(metadata.version("nox"), file=sys.stderr)
+        print(get_nox_version(), file=sys.stderr)
         return
 
     setup_logging(

--- a/nox/_version.py
+++ b/nox/_version.py
@@ -39,14 +39,14 @@ def get_nox_version() -> str:
     return metadata.version("nox")
 
 
-def _parse_string_constant(node: ast.AST) -> Optional[str]:
+def _parse_string_constant(node: ast.AST) -> Optional[str]:  # pragma: no cover
     """Return the value of a string constant."""
-    if sys.version_info < (3, 8):  # pragma: no cover
+    if sys.version_info < (3, 8):
         if isinstance(node, ast.Str) and isinstance(node.s, str):
             return node.s
     elif isinstance(node, ast.Constant) and isinstance(node.value, str):
         return node.value
-    return None  # pragma: no cover
+    return None
 
 
 def _parse_needs_version(source: str, filename: str = "<unknown>") -> Optional[str]:

--- a/nox/_version.py
+++ b/nox/_version.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import ast
+import sys
+from typing import Optional
+
 try:
     import importlib.metadata as metadata
 except ImportError:  # pragma: no cover
@@ -21,3 +25,38 @@ except ImportError:  # pragma: no cover
 def get_nox_version() -> str:
     """Return the version of the installed Nox package."""
     return metadata.version("nox")
+
+
+def _parse_string_constant(node: ast.AST) -> Optional[str]:
+    """Return the value of a string constant."""
+    if sys.version_info < (3, 8):  # pragma: no cover
+        if isinstance(node, ast.Str) and isinstance(node.s, str):
+            return node.s
+    elif isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None  # pragma: no cover
+
+
+def _parse_needs_version(source: str, filename: str = "<unknown>") -> Optional[str]:
+    """Parse ``nox.needs_version`` from the user's noxfile."""
+    value: Optional[str] = None
+    module: ast.Module = ast.parse(source, filename=filename)
+    for statement in module.body:
+        if isinstance(statement, ast.Assign):
+            for target in statement.targets:
+                if (
+                    isinstance(target, ast.Attribute)
+                    and isinstance(target.value, ast.Name)
+                    and target.value.id == "nox"
+                    and target.attr == "needs_version"
+                ):
+                    value = _parse_string_constant(statement.value)
+    return value
+
+
+def _read_needs_version(filename: str) -> Optional[str]:
+    """Read ``nox.needs_version`` from the user's noxfile."""
+    with open(filename) as io:
+        source = io.read()
+
+    return _parse_needs_version(source, filename=filename)

--- a/nox/_version.py
+++ b/nox/_version.py
@@ -89,7 +89,7 @@ def _check_nox_version_satisfies(needs_version: str) -> None:
 
     if not specifiers.contains(version, prereleases=True):
         raise VersionCheckFailed(
-            f"The Noxfile requires nox {specifiers}, you have {version}"
+            f"The Noxfile requires Nox {specifiers}, you have {version}"
         )
 
 

--- a/nox/_version.py
+++ b/nox/_version.py
@@ -1,0 +1,23 @@
+# Copyright 2021 Alethea Katherine Flowers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+try:
+    import importlib.metadata as metadata
+except ImportError:  # pragma: no cover
+    import importlib_metadata as metadata
+
+
+def get_nox_version() -> str:
+    """Return the version of the installed Nox package."""
+    return metadata.version("nox")

--- a/nox/_version.py
+++ b/nox/_version.py
@@ -93,14 +93,13 @@ def _check_nox_version_satisfies(needs_version: str) -> None:
         )
 
 
-def check_nox_version(filename: Optional[str] = None) -> None:
+def check_nox_version(filename: str) -> None:
     """Check if ``nox.needs_version`` in the user's noxfile is satisfied.
 
     Args:
-        filename: The location of the user's noxfile. When specified, read
-            ``nox.needs_version`` from the noxfile by parsing the AST.
-            Otherwise, assume that the noxfile was already imported, and
-            use ``nox.needs_version`` directly.
+
+        filename: The location of the user's noxfile. ``nox.needs_version`` is
+            read from the noxfile by parsing the AST.
 
     Raises:
         VersionCheckFailed: The Nox version does not satisfy what
@@ -108,10 +107,7 @@ def check_nox_version(filename: Optional[str] = None) -> None:
         InvalidVersionSpecifier: The ``nox.needs_version`` specifier cannot be
             parsed.
     """
-    from nox import needs_version
-
-    if filename is not None:
-        needs_version = _read_needs_version(filename)  # noqa: F811
+    needs_version = _read_needs_version(filename)
 
     if needs_version is not None:
         _check_nox_version_satisfies(needs_version)

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -60,14 +60,9 @@ def load_nox_module(global_config: Namespace) -> Union[types.ModuleType, int]:
         # import-time path resolutions work the way the Noxfile author would
         # guess.
         os.chdir(os.path.realpath(os.path.dirname(global_config.noxfile)))
-        module = importlib.machinery.SourceFileLoader(
+        return importlib.machinery.SourceFileLoader(
             "user_nox_module", global_config.noxfile
         ).load_module()  # type: ignore
-
-        # Check ``nox.needs_version`` as set by the Noxfile.
-        check_nox_version()
-
-        return module
 
     except (VersionCheckFailed, InvalidVersionSpecifier) as error:
         logger.error(str(error))

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
     install_requires=[
         "argcomplete>=1.9.4,<2.0",
         "colorlog>=2.6.1,<5.0.0",
+        "packaging>=20.9",
         "py>=1.4.0,<2.0.0",
         "virtualenv>=14.0.0",
         "importlib_metadata; python_version < '3.8'",

--- a/tests/test__version.py
+++ b/tests/test__version.py
@@ -1,0 +1,20 @@
+# Copyright 2021 Alethea Katherine Flowers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nox import needs_version
+
+
+def test_needs_version_default() -> None:
+    """It is None by default."""
+    assert needs_version is None

--- a/tests/test__version.py
+++ b/tests/test__version.py
@@ -13,8 +13,17 @@
 # limitations under the License.
 
 from nox import needs_version
+from nox._version import get_nox_version
+
 
 
 def test_needs_version_default() -> None:
     """It is None by default."""
     assert needs_version is None
+
+
+def test_get_nox_version() -> None:
+    """It returns something that looks like a Nox version."""
+    result = get_nox_version()
+    year, month, day = [int(part) for part in result.split(".")[:3]]
+    assert year >= 2020

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -18,6 +18,8 @@ import io
 import json
 import os
 import platform
+from pathlib import Path
+from textwrap import dedent
 from unittest import mock
 
 import nox
@@ -76,6 +78,31 @@ def test_load_nox_module_expandvars():
 
 def test_load_nox_module_not_found():
     config = _options.options.namespace(noxfile="bogus.py")
+    assert tasks.load_nox_module(config) == 2
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        dedent(
+            """
+            import nox
+            nox.needs_version = ">=9999.99.99"
+            """
+        ),
+        dedent(
+            """
+            import nox
+            NOX_NEEDS_VERSION = ">=9999.99.99"
+            nox.needs_version = NOX_NEEDS_VERSION
+            """
+        ),
+    ],
+)
+def test_load_nox_module_needs_version(text: str, tmp_path: Path):
+    noxfile = tmp_path / "noxfile.py"
+    noxfile.write_text(text)
+    config = _options.options.namespace(noxfile=str(noxfile))
     assert tasks.load_nox_module(config) == 2
 
 


### PR DESCRIPTION
Exit with a friendly error if the Nox version does not satisfy the requirements
specified by the user's Noxfile in `nox.needs_version`:

- Add dependency on [packaging] to Nox `install_requires`
- Add `nox.needs_version` attribute with [PEP 440] version specifiers for Nox
- Add `nox._version` module with these functions and classes:
  - function `get_nox_version`
  - function `check_nox_version`
  - exception `VersionCheckFailed`
  - exception `InvalidVersionSpecifier`
- Adapt `tasks.load_nox_module` to invoke `check_nox_version`
- Refactor `__main__` to use `get_nox_version` for `--version` option
- Tests and documentation

Closes #99
Supercedes #210

Some words about the approach taken here:

1. Rather than a minimum required version, `needs_version` accepts any [PEP 440]
   version specifier. Mostly, this just seemed a better conceptual match. If
   users specify a version `V`, Nox will suggest to use `>=V` instead.
   
   Version specifiers are also a much more expressive device. For example, a
   Noxfile could specify an upper bound if it has not been adapted to a breaking
   change in a newer Nox version. It could exclude a version with a bug that it
   was affected by. Nox, on its part, could offer a compatibility interface for
   older Noxfiles, should a large breaking change to the Nox API ever become
   necessary.
   
2. Version requirements are checked in two passes. In the first pass, Nox
   attempts to determine `nox.needs_version` from the [AST], using a best effort
   approach; if found, Nox checks the version a first time. The second pass
   occurs after the Noxfile was imported, and checks the version against
   `nox.needs_version` directly. The rationale is that we should avoid executing
   user code that wasn't written for our version. While parsing the AST should
   cover the majority of uses, the AST parser is kept deliberately simple;
   anything more complex than assigning a string literal is left for the second
   pass. A regular expression could have covered most of these use cases as
   well; however, parsing the AST seemed a better fit and not overly complex.

3. The implementation uses [packaging] instead of the [deprecated distutils
   module][PEP 632]. `LooseVersion` has been removed from the packaging API, and
   should not be needed anyway because, as a PyPI package, Nox versions conform
   to [PEP 440].

[AST]: https://docs.python.org/3/library/ast.html
[PEP 440]: https://www.python.org/dev/peps/pep-0440/
[PEP 632]: https://www.python.org/dev/peps/pep-0632/
[packaging]: https://packaging.pypa.io/en/stable/
