### PR TITLE
Preserve the order of parameterized arguments

### DIFF
--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -51,8 +51,7 @@ class Param:
             return self.id
         else:
             call_spec = self.call_spec
-            keys = sorted(call_spec.keys(), key=str)
-            args = ["{}={}".format(k, repr(call_spec[k])) for k in keys]
+            args = ["{}={}".format(k, repr(call_spec[k])) for k in call_spec.keys()]
             return ", ".join(args)
 
     __repr__ = __str__

--- a/tests/test__parametrize.py
+++ b/tests/test__parametrize.py
@@ -200,19 +200,19 @@ def test_generate_calls_multiple_args():
     f = mock.Mock()
     f.__name__ = "f"
 
-    arg_names = ("abc", "foo")
+    arg_names = ("foo", "abc")
     call_specs = [
-        _parametrize.Param(1, "a", arg_names=arg_names),
-        _parametrize.Param(2, "b", arg_names=arg_names),
-        _parametrize.Param(3, "c", arg_names=arg_names),
+        _parametrize.Param("a", 1, arg_names=arg_names),
+        _parametrize.Param("b", 2, arg_names=arg_names),
+        _parametrize.Param("c", 3, arg_names=arg_names),
     ]
 
     calls = _decorators.Call.generate_calls(f, call_specs)
 
     assert len(calls) == 3
-    assert calls[0].session_signature == "(abc=1, foo='a')"
-    assert calls[1].session_signature == "(abc=2, foo='b')"
-    assert calls[2].session_signature == "(abc=3, foo='c')"
+    assert calls[0].session_signature == "(foo='a', abc=1)"
+    assert calls[1].session_signature == "(foo='b', abc=2)"
+    assert calls[2].session_signature == "(foo='c', abc=3)"
 
     calls[0]()
     f.assert_called_with(abc=1, foo="a")


### PR DESCRIPTION
Parameterized jobs will now display in the same order as they are written.

```python
"""Example noxfile.py"""
import nox

@nox.session()
@nox.parameterize(
  ("z", "a"),
  [
    (1, 2),
    (3, 4),
  ]
)
def job(z, a):
    ...
```

### Before

```sh
% nox --list

* job(a=2, z=1)
* job(a=4, z=3)
```

### After

```sh
% nox --list

* job(z=1, a=2)
* job(z=3, a=4)
```

Closes #264

---

Thanks for the great library!