### PR TITLE
Ignore mypy configuration file

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -90,6 +90,7 @@ def lint(session):
     session.install("flake8==3.7.8", "black==19.3b0", "isort==4.3.21", "mypy==0.720")
     session.run(
         "mypy",
+        "--config-file=",
         "--disallow-untyped-defs",
         "--warn-unused-ignores",
         "--ignore-missing-imports",


### PR DESCRIPTION
Nox does not have a `mypy.ini` or `setup.cfg`. This will cause mypy to look for configuration files [in other directories](https://mypy.readthedocs.io/en/stable/config_file.html), which can cause failures when testing locally. This PR adds the `--config-file=` argument, which tells mypy to ignore config files.

---

Thanks!
