### PR TITLE
Adds option to skip Session dependency installs. Default is False. (#…

### DIFF
--- a/nox/_options.py
+++ b/nox/_options.py
@@ -402,6 +402,14 @@ options.add_options(
         hidden=True,
         finalizer_func=_color_finalizer,
     ),
+    _option_set.Option(
+        "no_install",
+        "--no-install",
+        default=False,
+        group=options.groups["secondary"],
+        action="store_true",
+        help="Skip invocations of session methods for installing packages.",
+    ),
 )
 
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -525,6 +525,10 @@ class SessionRunner:
         return _normalize_path(self.global_config.envdir, self.friendly_name)
 
     def _create_venv(self) -> None:
+        if self.global_config.no_install:
+            logger.info("Skipping _create_venv, as --no-install is set.")
+            return None
+
         backend = (
             self.global_config.force_venv_backend
             or self.func.venv_backend

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -290,6 +290,10 @@ class Session:
             do not have a virtualenv.
         :type external: bool
         """
+        if self._runner.global_config.no_install:
+            logger.info("Skipping run_always, as --no-install is set.")
+            return None
+
         if not args:
             raise ValueError("At least one argument required to run_always().")
 
@@ -355,6 +359,15 @@ class Session:
 
         .. _conda install:
         """
+
+        if self._runner.global_config.no_install:
+            logger.info(
+                "Skipping {} conda installation, as --no-install is set.".format(
+                    args[0]
+                )
+            )
+            return None
+
         venv = self._runner.venv
 
         prefix_args = ()  # type: Tuple[str, ...]
@@ -417,6 +430,13 @@ class Session:
 
         .. _pip: https://pip.readthedocs.org
         """
+
+        if self._runner.global_config.no_install:
+            logger.info(
+                "Skipping {} installation, as --no-install is set.".format(args[0])
+            )
+            return None
+
         if not isinstance(
             self._runner.venv, (CondaEnv, VirtualEnv, PassthroughEnv)
         ):  # pragma: no cover

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -742,6 +742,14 @@ class TestSessionRunner:
 
         assert result.status == nox.sessions.Status.SKIPPED
 
+    def test__create_venv_no_install(self, caplog):
+        runner = self.make_runner()
+
+        runner.global_config.no_install = True
+        runner._create_venv()
+
+        assert "Skipping _create_venv" in caplog.text
+
     def test_execute_with_manifest_null_session_func(self):
         runner = self.make_runner()
         runner.func = nox.manifest._null_session_func


### PR DESCRIPTION
  * skips pip installs
  * skips conda installs
  * skips run_always if no-install is set

-----
* I had problems figuring out how to actually run my local codebase, so I didn't get to do a sanity check on the command line. I'm still working on this...
* I wasn't entirely sure my error message in run_always was a good one