### PR TITLE
394 integrates no install flag

### DIFF
--- a/nox/_options.py
+++ b/nox/_options.py
@@ -402,6 +402,14 @@ options.add_options(
         hidden=True,
         finalizer_func=_color_finalizer,
     ),
+    _option_set.Option(
+        "no_install",
+        "--no-install",
+        default=False,
+        group=options.groups["secondary"],
+        action="store_true",
+        help="Skip invocations of session methods for installing packages.",
+    ),
 )
 
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -536,7 +536,7 @@ class SessionRunner:
             return
 
         reuse_existing = (
-            self.func.reuse_venv or self.global_config.reuse_existing_virtualenvs
+            self.func.reuse_venv or self.global_config.reuse_existing_virtualenvs or self.global_config.no_install
         )
 
         if backend is None or backend == "virtualenv":

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -360,15 +360,22 @@ class Session:
         .. _conda install:
         """
 
-        if self._runner.global_config.no_install:
-            logger.info(
-                "Skipping {} conda installation, as --no-install is set.".format(
-                    args[0]
-                )
-            )
-            return None
-
         venv = self._runner.venv
+
+        if self._runner.global_config.no_install:
+            if (venv.venv_created):
+                logger.info(
+                    "Skipping {} conda installation, as --no-install is set.".format(
+                        args[0]
+                    )
+                )
+                return None
+            else:
+                logger.info(
+                    "Venv not created yet. Ignoring --no-install and installing {} via conda.".format(
+                        args[0]
+                    )
+                )
 
         prefix_args = ()  # type: Tuple[str, ...]
         if isinstance(venv, CondaEnv):
@@ -525,6 +532,7 @@ class SessionRunner:
         return _normalize_path(self.global_config.envdir, self.friendly_name)
 
     def _create_venv(self) -> None:
+
         backend = (
             self.global_config.force_venv_backend
             or self.func.venv_backend

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -290,6 +290,10 @@ class Session:
             do not have a virtualenv.
         :type external: bool
         """
+        if self._runner.global_config.no_install:
+            logger.info("Skipping run_always, as --no-install is set.")
+            return None
+
         if not args:
             raise ValueError("At least one argument required to run_always().")
 
@@ -355,6 +359,15 @@ class Session:
 
         .. _conda install:
         """
+
+        if self._runner.global_config.no_install:
+            logger.info(
+                "Skipping {} conda installation, as --no-install is set.".format(
+                    args[0]
+                )
+            )
+            return None
+
         venv = self._runner.venv
 
         prefix_args = ()  # type: Tuple[str, ...]
@@ -417,6 +430,13 @@ class Session:
 
         .. _pip: https://pip.readthedocs.org
         """
+
+        if self._runner.global_config.no_install:
+            logger.info(
+                "Skipping {} installation, as --no-install is set.".format(args[0])
+            )
+            return None
+
         if not isinstance(
             self._runner.venv, (CondaEnv, VirtualEnv, PassthroughEnv)
         ):  # pragma: no cover

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -55,6 +55,8 @@ class ProcessEnv:
         self._bin_paths = bin_paths
         self.env = os.environ.copy()
 
+        self._venv_created = False
+
         if env is not None:
             self.env.update(env)
 
@@ -77,6 +79,11 @@ class ProcessEnv:
         if paths is None:
             raise ValueError("The environment does not have a bin directory.")
         return paths[0]
+
+    @property
+    def venv_created(self):
+        return self._venv_created
+    
 
     def create(self) -> bool:
         raise NotImplementedError("ProcessEnv.create should be overwritten in subclass")
@@ -249,6 +256,8 @@ class CondaEnv(ProcessEnv):
         )
         nox.command.run(cmd, silent=True, log=False)
 
+        self.venv_created = True
+
         return True
 
     @staticmethod
@@ -418,4 +427,6 @@ class VirtualEnv(ProcessEnv):
         )
         nox.command.run(cmd, silent=True, log=False)
 
+        self._venv_created = True
+        
         return True


### PR DESCRIPTION
* Adds a new option, `--no-install`. This is used to skip installing packages if the packages have been installed once.
* Adds a boolean to the virtualenv base class, `venv_created`, which tracks whether or not the virtual environment has already been created. The `--no-install` flag behaves differently dependent upon whether a venv is already created or not.
  * If no virtualenv is present, a message is logged that `no-install` is being ignored and normal installations proceed.
  * If a virtualenv is already present, `--no-install` prevents the installation of packages.
* Adds tests to validate the above 
* Also refactors `SessionNoSlots` into an extracted class `MockableSession`. This followed from scratching my head trying to understand what SessionNoSlots provided, and then heading to the PR which implemented it (https://github.com/theacodes/nox/pull/128) to see what the class was buying the tests.
