### PR TITLE
Add normalized comparison to check sessions (#396)

### DIFF
--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -22,6 +22,8 @@ from nox.manifest import (
     WARN_PYTHONS_IGNORED,
     KeywordLocals,
     Manifest,
+    _normalize_arg,
+    _normalized_session_match,
     _null_session_func,
 )
 
@@ -40,6 +42,22 @@ def create_mock_config():
     cfg.extra_pythons = None
     cfg.posargs = []
     return cfg
+
+
+def test__normalize_arg():
+    assert _normalize_arg('test(foo="bar")') == _normalize_arg('test(foo="bar")')
+
+    # In the case of SyntaxError it should fallback to strng
+    assert (
+        _normalize_arg("datetime.datetime(1990; 2, 18),")
+        == "datetime.datetime(1990; 2, 18),"
+    )
+
+
+def test__normalized_session_match():
+    session_mock = mock.MagicMock()
+    session_mock.signatures = ['test(foo="bar")']
+    assert _normalized_session_match("test(foo='bar')", session_mock)
 
 
 def test_init():


### PR DESCRIPTION
First of all, thanks for this amazing tool, I started to use it recently (I come from the `tox` world)

This is a possible fix for (#396):

- Attempt to do the previous checks
- On fail, it will normalize arguments using ast (based on discussion)
- The comparison will be on ast representation of the strings
- Add unit tests
