### PR TITLE
fix position of venv_params within conda create

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -226,17 +226,12 @@ class CondaEnv(ProcessEnv):
             )
             return False
 
-        cmd = [
-            "conda",
-            "create",
-            "--yes",
-            "--prefix",
-            self.location,
-            # Ensure the pip package is installed.
-            "pip",
-        ]
+        cmd = ["conda", "create", "--yes", "--prefix", self.location]
 
         cmd.extend(self.venv_params)
+
+        # Ensure the pip package is installed.
+        cmd.append("pip")
 
         if self.interpreter:
             python_dep = "python={}".format(self.interpreter)

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -182,6 +182,18 @@ def test_condaenv_create(make_conda):
 
 
 @pytest.mark.skipif(not HAS_CONDA, reason="Missing conda command.")
+def test_condaenv_create_with_params(make_conda):
+    venv, dir_ = make_conda(venv_params=["--verbose"])
+    venv.create()
+    if IS_WINDOWS:
+        assert dir_.join("python.exe").check()
+        assert dir_.join("Scripts", "pip.exe").check()
+    else:
+        assert dir_.join("bin", "python").check()
+        assert dir_.join("bin", "pip").check()
+
+
+@pytest.mark.skipif(not HAS_CONDA, reason="Missing conda command.")
 def test_condaenv_create_interpreter(make_conda):
     venv, dir_ = make_conda(interpreter="3.7")
     venv.create()


### PR DESCRIPTION
Fixes #419 by moving 'pip' to after venv_params