### PR TITLE
use standatd contextlib instead outdates contexter

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -332,7 +332,7 @@ incompatible versions of packages already installed with conda.
 
 .. code-block:: python
 
-    session.install("contexter", "--no-deps")
+    session.install("contextlib", "--no-deps")
     session.install("-e", ".", "--no-deps")
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -58,7 +58,7 @@ def conda_tests(session):
     session.conda_install(
         "--file", "requirements-conda-test.txt", "--channel", "conda-forge"
     )
-    session.install("contexter", "--no-deps")
+    session.install("contextlib", "--no-deps")
     session.install("-e", ".", "--no-deps")
     tests = session.posargs or ["tests/"]
     session.run("pytest", *tests)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 flask
 pytest
 pytest-cov
-contexter
+contextlib
 sphinx
 sphinx-autobuild
 recommonmark

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -17,7 +17,7 @@ import sys
 from pathlib import Path
 from unittest import mock
 
-import contexter
+import contextlib
 import nox
 import nox.__main__
 import nox._options
@@ -296,7 +296,7 @@ def test_main_positional_flag_like_with_double_hyphen(monkeypatch):
 def test_main_version(capsys, monkeypatch):
     monkeypatch.setattr(sys, "argv", [sys.executable, "--version"])
 
-    with contexter.ExitStack() as stack:
+    with contextlib.ExitStack() as stack:
         execute = stack.enter_context(mock.patch("nox.workflow.execute"))
         exit_mock = stack.enter_context(mock.patch("sys.exit"))
         nox.__main__.main()
@@ -309,7 +309,7 @@ def test_main_version(capsys, monkeypatch):
 def test_main_help(capsys, monkeypatch):
     monkeypatch.setattr(sys, "argv", [sys.executable, "--help"])
 
-    with contexter.ExitStack() as stack:
+    with contextlib.ExitStack() as stack:
         execute = stack.enter_context(mock.patch("nox.workflow.execute"))
         exit_mock = stack.enter_context(mock.patch("sys.exit"))
         nox.__main__.main()


### PR DESCRIPTION
contexter module is not maintained since 2017.

Tested using pytest
```console
$ /usr/bin/python3 -Bm pytest -ra tests/test_sessions.py
===================== test session starts ===============================
platform linux -- Python 3.8.9, pytest-6.2.3, py-1.10.0, pluggy-0.13.1
rootdir: /home/tkloczko/rpmbuild/BUILD/nox-2020.12.31
plugins: forked-1.3.0, shutil-1.7.0, virtualenv-1.7.0, asyncio-0.14.0, expect-1.1.0, cov-2.11.1, mock-3.5.1, httpbin-1.0.0, xdist-2.2.1, flake8-1.0.7, timeout-1.4.2, betamax-0.8.1, pyfakefs-4.4.0, freezegun-0.4.2, flaky-3.7.0, cases-3.4.6, hypothesis-6.10.1, case-1.5.3, isort-1.3.0, aspectlib-1.5.2
collected 77 items

tests/test_sessions.py .............................................................................[100%]

====================== 77 passed in 1.53s ================================
```