### PR TITLE
Drop contexter from test requirements

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -58,7 +58,6 @@ def conda_tests(session):
     session.conda_install(
         "--file", "requirements-conda-test.txt", "--channel", "conda-forge"
     )
-    session.install("contexter", "--no-deps")
     session.install("-e", ".", "--no-deps")
     tests = session.posargs or ["tests/"]
     session.run("pytest", *tests)

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,6 @@
 flask
 pytest
 pytest-cov
-contexter
 sphinx
 sphinx-autobuild
 recommonmark

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,12 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import os
 import sys
 from pathlib import Path
 from unittest import mock
 
-import contexter
 import nox
 import nox.__main__
 import nox._options
@@ -296,7 +296,7 @@ def test_main_positional_flag_like_with_double_hyphen(monkeypatch):
 def test_main_version(capsys, monkeypatch):
     monkeypatch.setattr(sys, "argv", [sys.executable, "--version"])
 
-    with contexter.ExitStack() as stack:
+    with contextlib.ExitStack() as stack:
         execute = stack.enter_context(mock.patch("nox.workflow.execute"))
         exit_mock = stack.enter_context(mock.patch("sys.exit"))
         nox.__main__.main()
@@ -309,7 +309,7 @@ def test_main_version(capsys, monkeypatch):
 def test_main_help(capsys, monkeypatch):
     monkeypatch.setattr(sys, "argv", [sys.executable, "--help"])
 
-    with contexter.ExitStack() as stack:
+    with contextlib.ExitStack() as stack:
         execute = stack.enter_context(mock.patch("nox.workflow.execute"))
         exit_mock = stack.enter_context(mock.patch("sys.exit"))
         nox.__main__.main()


### PR DESCRIPTION
The contexter package is a third-party backport of contextlib (with some
extensions). It is no longer required because Nox does not support Python 2
anymore, and we only ever used the standard ExitStack interface.

The contexter package was used only in the test suite.

Supercedes #421 
