### PR TITLE
Fix environments not being reused due to wrong Python lookup

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -336,9 +336,9 @@ class VirtualEnv(ProcessEnv):
         """Check if reused environment interpreter is the same."""
         program = "import sys; print(getattr(sys, 'real_prefix', sys.base_prefix))"
         original = nox.command.run(
-            [self._resolved_interpreter, "-c", program], silent=True
+            [self._resolved_interpreter, "-c", program], silent=True, log=False
         )
-        created = nox.command.run(["python", "-c", program], silent=True)
+        created = nox.command.run(["python", "-c", program], silent=True, log=False)
         return original == created
 
     @property

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -338,7 +338,9 @@ class VirtualEnv(ProcessEnv):
         original = nox.command.run(
             [self._resolved_interpreter, "-c", program], silent=True, log=False
         )
-        created = nox.command.run(["python", "-c", program], silent=True, log=False)
+        created = nox.command.run(
+            ["python", "-c", program], silent=True, log=False, paths=self.bin_paths
+        )
         return original == created
 
     @property

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -424,6 +424,7 @@ def test_create_reuse_venv_environment(make_one):
     assert reused
 
 
+@pytest.mark.skipif(IS_WINDOWS, reason="Avoid 'No pyvenv.cfg file' error on Windows.")
 def test_create_reuse_oldstyle_virtualenv_environment(make_one):
     venv, location = make_one(reuse_existing=True)
     venv.create()

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -410,13 +410,9 @@ def test_create_reuse_venv_environment(make_one):
     venv, location = make_one(reuse_existing=True, venv=True)
     venv.create()
 
-    # Use a spurious occurrence of "virtualenv" in the pyvenv.cfg.
-    pyvenv_cfg = """\
-    home = /opt/virtualenv/bin
-    include-system-site-packages = false
-    version = 3.9.6
-    """
-    location.join("pyvenv.cfg").write(dedent(pyvenv_cfg))
+    # Place a spurious occurrence of "virtualenv" in the pyvenv.cfg.
+    pyvenv_cfg = location.join("pyvenv.cfg")
+    pyvenv_cfg.write(pyvenv_cfg.read() + "bogus = virtualenv\n")
 
     reused = not venv.create()
 


### PR DESCRIPTION
_Follow-up to #418 and #425_

This PR contains two changes to the staleness check when reusing environments:

**1. Fix environments not being reused due to wrong Python lookup**

When determining the Python base installation of an existing environment, allow `nox.command.run` to find the Python executable in the virtualenv, by passing `VirtualEnv.bin_paths` as the `paths` argument.

The original PR (#418) passed `os.path.join(self.location, "bin", "python")`. This does not work for two reasons:

- The directory is named "Scripts" on Windows.
- The executable is named "python.exe" on Windows.

The follow-up PR (#425) passed bare "python". This does not work, because `nox.command.run` searches `PATH` by default. It needs to be told to search the virtualenv instead.

This fix exposed portability flaws in the test suite on Windows. Some tests messed with the `pyvenv.cfg` files, which confused the Windows Python launcher. We solve this by skipping one non-essential test on Windows, and by preserving the original `pyvenv.cfg` keys in another test.

**2. Don't log interpreter checks when reusing environments**

This gets rid of some clutter in the Nox output. Here's an example for such clutter:

```sh
nox > Running session test
nox > /usr/local/bin/python -c import sys; print(getattr(sys, 'real_prefix', sys.base_prefix))
nox > python -c import sys; print(getattr(sys, 'real_prefix', sys.base_prefix))
nox > Re-using existing virtual environment at .nox/test.
nox > Session test was successful.
```
