### PR TITLE
Allow colorlog <7.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     zip_safe=False,
     install_requires=[
         "argcomplete>=1.9.4,<2.0",
-        "colorlog>=2.6.1,<5.0.0",
+        "colorlog>=2.6.1,<7.0.0",
         "packaging>=20.9",
         "py>=1.4.0,<2.0.0",
         "virtualenv>=14.0.0",


### PR DESCRIPTION
5 is the latest release, and 6.x just drops support for Python 2, so we should be good.

Fixes #430 