### PR TITLE
Upgrade linters to the latest version

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,6 +1,2 @@
 [settings]
-multi_line_output=3
-include_trailing_comma=True
-force_grid_wrap=0
-use_parentheses=True
-line_length=88
+profile=black

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -27,7 +27,7 @@ def _copy_func(src: Callable, name: str = None) -> Callable:
         closure=src.__closure__,  # type: ignore
     )
     dst.__dict__.update(copy.deepcopy(src.__dict__))
-    dst = functools.update_wrapper(dst, src)  # type: ignore
+    dst = functools.update_wrapper(dst, src)
     dst.__kwdefaults__ = src.__kwdefaults__  # type: ignore
     return dst
 

--- a/nox/_version.py
+++ b/nox/_version.py
@@ -20,9 +20,9 @@ from typing import Optional
 from packaging.specifiers import InvalidSpecifier, SpecifierSet
 from packaging.version import InvalidVersion, Version
 
-try:
+if sys.version_info >= (3, 8):  # pragma: no cover
     import importlib.metadata as metadata
-except ImportError:  # pragma: no cover
+else:  # pragma: no cover
     import importlib_metadata as metadata
 
 

--- a/nox/command.py
+++ b/nox/command.py
@@ -17,6 +17,7 @@ import sys
 from typing import Any, Iterable, List, Optional, Sequence, Union
 
 import py
+
 from nox.logger import logger
 from nox.popen import popen
 

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -16,10 +16,10 @@ import contextlib
 import locale
 import subprocess
 import sys
-from typing import IO, Mapping, Optional, Sequence, Tuple, Union
+from typing import IO, Mapping, Sequence, Tuple, Union
 
 
-def shutdown_process(proc: subprocess.Popen) -> Tuple[Optional[bytes], Optional[bytes]]:
+def shutdown_process(proc: subprocess.Popen) -> Tuple[bytes, bytes]:
     """Gracefully shutdown a child process."""
 
     with contextlib.suppress(subprocess.TimeoutExpired):

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -32,8 +32,9 @@ from typing import (
     Union,
 )
 
-import nox.command
 import py
+
+import nox.command
 from nox import _typing
 from nox._decorators import Func
 from nox.logger import logger

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -20,8 +20,9 @@ import types
 from argparse import Namespace
 from typing import List, Union
 
-import nox
 from colorlog.escape_codes import parse_colors
+
+import nox
 from nox import _options, registry
 from nox._version import InvalidVersionSpecifier, VersionCheckFailed, check_nox_version
 from nox.logger import logger

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -20,8 +20,9 @@ import sys
 from socket import gethostbyname
 from typing import Any, List, Mapping, Optional, Tuple, Union
 
-import nox.command
 import py
+
+import nox.command
 from nox.logger import logger
 
 from . import _typing

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -329,7 +329,7 @@ class VirtualEnv(ProcessEnv):
             # virtualenv < 20.0 does not create pyvenv.cfg
             old_env = "virtualenv"
         else:
-            pattern = re.compile(f"virtualenv[ \t]*=")
+            pattern = re.compile("virtualenv[ \t]*=")
             with open(path) as fp:
                 old_env = (
                     "virtualenv" if any(pattern.match(line) for line in fp) else "venv"

--- a/noxfile.py
+++ b/noxfile.py
@@ -78,7 +78,7 @@ def cover(session):
 @nox.session(python="3.8")
 def blacken(session):
     """Run black code formatter."""
-    session.install("black==19.3b0", "isort==4.3.21")
+    session.install("black==21.5b2", "isort==4.3.21")
     files = ["nox", "tests", "noxfile.py", "setup.py"]
     session.run("black", *files)
     session.run("isort", "--recursive", *files)
@@ -86,7 +86,7 @@ def blacken(session):
 
 @nox.session(python="3.8")
 def lint(session):
-    session.install("flake8==3.7.8", "black==19.3b0", "isort==4.3.21", "mypy==0.720")
+    session.install("flake8==3.7.8", "black==21.5b2", "isort==4.3.21", "mypy==0.720")
     session.run(
         "mypy",
         "--config-file=",

--- a/noxfile.py
+++ b/noxfile.py
@@ -86,7 +86,7 @@ def blacken(session):
 
 @nox.session(python="3.8")
 def lint(session):
-    session.install("flake8==3.7.8", "black==21.5b2", "isort==4.3.21", "mypy==0.720")
+    session.install("flake8==3.9.2", "black==21.5b2", "isort==4.3.21", "mypy==0.720")
     session.run(
         "mypy",
         "--config-file=",

--- a/noxfile.py
+++ b/noxfile.py
@@ -78,7 +78,7 @@ def cover(session):
 @nox.session(python="3.8")
 def blacken(session):
     """Run black code formatter."""
-    session.install("black==21.5b2", "isort==4.3.21")
+    session.install("black==21.5b2", "isort==5.8.0")
     files = ["nox", "tests", "noxfile.py", "setup.py"]
     session.run("black", *files)
     session.run("isort", "--recursive", *files)
@@ -86,7 +86,7 @@ def blacken(session):
 
 @nox.session(python="3.8")
 def lint(session):
-    session.install("flake8==3.9.2", "black==21.5b2", "isort==4.3.21", "mypy==0.720")
+    session.install("flake8==3.9.2", "black==21.5b2", "isort==5.8.0", "mypy==0.720")
     session.run(
         "mypy",
         "--config-file=",

--- a/noxfile.py
+++ b/noxfile.py
@@ -81,7 +81,7 @@ def blacken(session):
     session.install("black==21.5b2", "isort==5.8.0")
     files = ["nox", "tests", "noxfile.py", "setup.py"]
     session.run("black", *files)
-    session.run("isort", "--recursive", *files)
+    session.run("isort", *files)
 
 
 @nox.session(python="3.8")
@@ -97,7 +97,7 @@ def lint(session):
     )
     files = ["nox", "tests", "noxfile.py", "setup.py"]
     session.run("black", "--check", *files)
-    session.run("isort", "--check", "--recursive", *files)
+    session.run("isort", "--check", *files)
     session.run("flake8", *files)
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -98,7 +98,7 @@ def lint(session):
     files = ["nox", "tests", "noxfile.py", "setup.py"]
     session.run("black", "--check", *files)
     session.run("isort", "--check", "--recursive", *files)
-    session.run("flake8", "nox", *files)
+    session.run("flake8", *files)
 
 
 @nox.session(python="3.7")

--- a/noxfile.py
+++ b/noxfile.py
@@ -86,7 +86,7 @@ def blacken(session):
 
 @nox.session(python="3.8")
 def lint(session):
-    session.install("flake8==3.9.2", "black==21.5b2", "isort==5.8.0", "mypy==0.720")
+    session.install("flake8==3.9.2", "black==21.5b2", "isort==5.8.0", "mypy==0.812")
     session.run(
         "mypy",
         "--config-file=",

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+
 from nox import _option_set, _options
 
 # The vast majority of _option_set is tested by test_main, but the test helper

--- a/tests/test__parametrize.py
+++ b/tests/test__parametrize.py
@@ -15,6 +15,7 @@
 from unittest import mock
 
 import pytest
+
 from nox import _decorators, _parametrize, parametrize, session
 
 

--- a/tests/test__version.py
+++ b/tests/test__version.py
@@ -17,6 +17,7 @@ from textwrap import dedent
 from typing import Optional
 
 import pytest
+
 from nox import needs_version
 from nox._version import (
     InvalidVersionSpecifier,

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -23,9 +23,10 @@ import time
 from textwrap import dedent
 from unittest import mock
 
+import pytest
+
 import nox.command
 import nox.popen
-import pytest
 
 PYTHON = sys.executable
 

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -474,7 +474,7 @@ def test_output_decoding_utf8_only_fail(monkeypatch: pytest.MonkeyPatch) -> None
 
 
 def test_output_decoding_utf8_fail_cp1252_success(
-    monkeypatch: pytest.MonkeyPatch
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(nox.popen.locale, "getpreferredencoding", lambda: "cp1252")
 

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -16,6 +16,7 @@ import logging
 from unittest import mock
 
 import pytest
+
 from nox import logger
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,12 +18,13 @@ import sys
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 import nox
 import nox.__main__
 import nox._options
 import nox.registry
 import nox.sessions
-import pytest
 
 try:
     import importlib.metadata as metadata

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -15,8 +15,9 @@
 import collections
 from unittest import mock
 
-import nox
 import pytest
+
+import nox
 from nox._decorators import Func
 from nox.manifest import (
     WARN_PYTHONS_IGNORED,

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import pytest
+
 from nox import registry
 
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -21,12 +21,13 @@ import tempfile
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 import nox.command
 import nox.manifest
 import nox.registry
 import nox.sessions
 import nox.virtualenv
-import pytest
 from nox import _options
 from nox.logger import logger
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -21,8 +21,9 @@ import platform
 from textwrap import dedent
 from unittest import mock
 
-import nox
 import pytest
+
+import nox
 from nox import _options, sessions, tasks
 from nox.manifest import WARN_PYTHONS_IGNORED, Manifest
 

--- a/tests/test_tox_to_nox.py
+++ b/tests/test_tox_to_nox.py
@@ -16,6 +16,7 @@ import sys
 import textwrap
 
 import pytest
+
 from nox import tox_to_nox
 
 

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -18,9 +18,10 @@ import sys
 from textwrap import dedent
 from unittest import mock
 
-import nox.virtualenv
 import py
 import pytest
+
+import nox.virtualenv
 
 IS_WINDOWS = nox.virtualenv._SYSTEM == "Windows"
 HAS_CONDA = shutil.which("conda") is not None


### PR DESCRIPTION
Bump the dependencies of Nox's lint session:

- Bump black from 19.3b0 to 21.5b2
- Bump flake8 from 3.7.8 to 3.9.2
- Bump isort from 4.3.21 to 5.8.0
- Bump mypy from 0.720 to 0.812

Fix new warnings and type errors.

Apply changes in code style and import ordering.

Use the new profile feature of isort 5 to achieve compatibility with black.

Supercedes #435
Supercedes #436
Supercedes #437