### PR TITLE
Avoid polluting tests with a .nox directory

### DIFF
--- a/tests/resources/noxfile_normalization.py
+++ b/tests/resources/noxfile_normalization.py
@@ -7,7 +7,7 @@ class Foo:
     pass
 
 
-@nox.session
+@nox.session(venv_backend="none")
 @nox.parametrize(
     "arg",
     ["Jane", "Joe's", '"hello world"', datetime.datetime(1980, 1, 1), [42], Foo()],


### PR DESCRIPTION
Fixes #443 
Follow-up to #434 

The test `test_main_with_normalized_session_names` from #434 creates a `.nox` directory under `tests/resources`. This breaks the linting session. Avoid this by passing `venv_backend="none"` to the session decorator.