### PR TITLE
Hide staleness check behind a feature flag

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -33,6 +33,7 @@ _BLACKLISTED_ENV_VARS = frozenset(
     ["PIP_RESPECT_VIRTUALENV", "PIP_REQUIRE_VIRTUALENV", "__PYVENV_LAUNCHER__"]
 )
 _SYSTEM = platform.system()
+_ENABLE_STALENESS_CHECK = "NOX_ENABLE_STALENESS_CHECK" in os.environ
 
 
 class InterpreterNotFound(OSError):
@@ -312,6 +313,8 @@ class VirtualEnv(ProcessEnv):
     def _clean_location(self) -> bool:
         """Deletes any existing virtual environment"""
         if os.path.exists(self.location):
+            if self.reuse_existing and not _ENABLE_STALENESS_CHECK:
+                return False
             if (
                 self.reuse_existing
                 and self._check_reused_environment_type()

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -352,6 +352,15 @@ def test_create_reuse_environment(make_one):
     assert reused
 
 
+@pytest.fixture
+def _enable_staleness_check(monkeypatch):
+    monkeypatch.setattr("nox.virtualenv._ENABLE_STALENESS_CHECK", True)
+
+
+enable_staleness_check = pytest.mark.usefixtures("_enable_staleness_check")
+
+
+@enable_staleness_check
 def test_create_reuse_environment_with_different_interpreter(make_one, monkeypatch):
     venv, location = make_one(reuse_existing=True)
     venv.create()
@@ -368,6 +377,7 @@ def test_create_reuse_environment_with_different_interpreter(make_one, monkeypat
     assert not location.join("marker").check()
 
 
+@enable_staleness_check
 def test_create_reuse_stale_venv_environment(make_one):
     venv, location = make_one(reuse_existing=True)
     venv.create()
@@ -387,6 +397,7 @@ def test_create_reuse_stale_venv_environment(make_one):
     assert not reused
 
 
+@enable_staleness_check
 def test_create_reuse_stale_virtualenv_environment(make_one):
     venv, location = make_one(reuse_existing=True, venv=True)
     venv.create()
@@ -411,6 +422,7 @@ def test_create_reuse_stale_virtualenv_environment(make_one):
     assert not reused
 
 
+@enable_staleness_check
 def test_create_reuse_venv_environment(make_one):
     venv, location = make_one(reuse_existing=True, venv=True)
     venv.create()
@@ -425,6 +437,7 @@ def test_create_reuse_venv_environment(make_one):
     assert reused
 
 
+@enable_staleness_check
 @pytest.mark.skipif(IS_WINDOWS, reason="Avoid 'No pyvenv.cfg file' error on Windows.")
 def test_create_reuse_oldstyle_virtualenv_environment(make_one):
     venv, location = make_one(reuse_existing=True)

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -455,6 +455,7 @@ def test_create_reuse_oldstyle_virtualenv_environment(make_one):
     assert reused
 
 
+@enable_staleness_check
 def test_create_reuse_python2_environment(make_one):
     venv, location = make_one(reuse_existing=True, interpreter="2.7")
 


### PR DESCRIPTION
This PR introduces a feature flag for the staleness check when reusing environments.

The staleness check is deactivated by default. It can be enabled by setting `NOX_ENABLE_STALENESS_CHECK` in the environment. This is an experimental feature, and the environment variable is not a part of Nox's public API. 

See https://github.com/theacodes/nox/issues/449#issuecomment-860030890 for background
