### PR TITLE
Release 2021.6.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2021.6.12
+
+- Fix crash on Python 2 when reusing environments. (#450)
+- Hide staleness check behind a feature flag. (#451)
+- Group command-line options in `--help` message by function. (#442)
+- Avoid polluting tests with a .nox directory. (#445)
+
 ## 2021.6.6
 
 - Add option `--no-install` to skip install commands in reused environments. (#432)

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ long_description = open("README.rst", "r", encoding="utf-8").read()
 
 setup(
     name="nox",
-    version="2021.6.6",
+    version="2021.6.12",
     description="Flexible test automation.",
     long_description=long_description,
     url="https://nox.thea.codes",


### PR DESCRIPTION
- Fix crash on Python 2 when reusing environments. (#450)
- Hide staleness check behind a feature flag. (#451)
- Group command-line options in `--help` message by function. (#442)
- Avoid polluting tests with a .nox directory. (#445)