### PR TITLE
chore: Use PEP 517 build system

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
This makes the pyproject.toml file available for configuration (such as for #455).

#### Pros:

* Gives correct results if wheel is missing (normally a non-wheel build is made, which doesn't pre-cache all pyc files, etc).
* Gives correct results in an environment without setuptools (starting to become more common).
* Is not affected by the current Python environment's installs.
* No effect on legacy pips (pip 9 or less), they work as before.
* Enables using the file for other configuration.
* Likely will become the pip default in the future.


#### Cons:

* Can be slightly slower (1-2 seconds) when building from source due to setting up a temporary virtual environment. Besides "correctness is better than speed" for building, this is almost never activated, since this is a pure Python project and has wheels. Users installing from wheels do not even have the pyproject.toml file or setup.py file anyway.
* Causes pip to be really verbose when you add `-v` about trivial package searching.

#### Wrongly considered cons:

* This does not mean you have to access the internet when building from source. If a package is cached that matches the requirements (say, setuptools 43 is present), then it just uses that and doesn't need to access PyPI.
* For special situations, you can disable the build isolation; conda-build for example does this.
