### PR TITLE
chore: use setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,60 @@
+[metadata]
+name = nox
+version = 2021.6.12
+description = Flexible test automation.
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+url = https://nox.thea.codes
+author = Alethea Katherine Flowers
+author_email = me@thea.codes
+license = Apache-2.0
+license_file = LICENSE
+classifiers =
+    Development Status :: 5 - Production/Stable
+    Environment :: Console
+    Intended Audience :: Developers
+    License :: OSI Approved :: Apache Software License
+    Operating System :: MacOS
+    Operating System :: Microsoft :: Windows
+    Operating System :: POSIX
+    Operating System :: Unix
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Topic :: Software Development :: Testing
+keywords = testing automation tox
+project_urls =
+    Documentation = https://nox.thea.codes
+    Source Code = https://github.com/theacodes/nox
+    Bug Tracker = https://github.com/theacodes/nox/issues
+
+[options]
+packages =
+    nox
+install_requires =
+    argcomplete>=1.9.4,<2.0
+    colorlog>=2.6.1,<7.0.0
+    packaging>=20.9
+    py>=1.4.0,<2.0.0
+    virtualenv>=14.0.0
+    importlib_metadata;python_version < '3.8'
+python_requires = >=3.6
+include_package_data = True
+zip_safe = False
+
+[options.entry_points]
+console_scripts =
+    nox = nox.__main__:main
+    tox-to-nox = nox.tox_to_nox:main [tox_to_nox]
+
+[options.extras_require]
+tox_to_nox =
+    jinja2
+    tox
+
+[options.package_data]
+nox = py.typed

--- a/setup.py
+++ b/setup.py
@@ -12,62 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from codecs import open
-
 from setuptools import setup
 
-long_description = open("README.rst", "r", encoding="utf-8").read()
-
-setup(
-    name="nox",
-    version="2021.6.12",
-    description="Flexible test automation.",
-    long_description=long_description,
-    url="https://nox.thea.codes",
-    author="Alethea Katherine Flowers",
-    author_email="me@thea.codes",
-    license="Apache Software License",
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: Apache Software License",
-        "Topic :: Software Development :: Testing",
-        "Environment :: Console",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Operating System :: POSIX",
-        "Operating System :: MacOS",
-        "Operating System :: Unix",
-        "Operating System :: Microsoft :: Windows",
-    ],
-    keywords="testing automation tox",
-    packages=["nox"],
-    package_data={"nox": ["py.typed"]},
-    include_package_data=True,
-    zip_safe=False,
-    install_requires=[
-        "argcomplete>=1.9.4,<2.0",
-        "colorlog>=2.6.1,<7.0.0",
-        "packaging>=20.9",
-        "py>=1.4.0,<2.0.0",
-        "virtualenv>=14.0.0",
-        "importlib_metadata; python_version < '3.8'",
-    ],
-    extras_require={"tox_to_nox": ["jinja2", "tox"]},
-    entry_points={
-        "console_scripts": [
-            "nox=nox.__main__:main",
-            "tox-to-nox=nox.tox_to_nox:main [tox_to_nox]",
-        ]
-    },
-    project_urls={
-        "Documentation": "https://nox.thea.codes",
-        "Source Code": "https://github.com/theacodes/nox",
-        "Bug Tracker": "https://github.com/theacodes/nox/issues",
-    },
-    python_requires=">=3.6",
-)
+setup()


### PR DESCRIPTION
Since this was mentioned in #455 and I happen to have a tool that does 90% of the conversion automatically, here's the setup.cfg conversion. Shouldn't change anything. I left a token setup.py, but it's not even needed anymore even for editable installs on the latest version of pip. You can't remove the file completely though until you have a pyproject.toml file. But once you do, you can remove it if you want.
