### PR TITLE
Add friendlier message if no noxfile.py

### DIFF
--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -52,6 +52,7 @@ def load_nox_module(global_config: Namespace) -> Union[types.ModuleType, int]:
             # Be sure to expand variables
             os.path.expandvars(global_config.noxfile)
         )
+        noxfile_parent_dir = os.path.realpath(os.path.dirname(global_config.noxfile))
 
         # Check ``nox.needs_version`` by parsing the AST.
         check_nox_version(global_config.noxfile)
@@ -60,13 +61,16 @@ def load_nox_module(global_config: Namespace) -> Union[types.ModuleType, int]:
         # This will ensure that the Noxfile's path is on sys.path, and that
         # import-time path resolutions work the way the Noxfile author would
         # guess.
-        os.chdir(os.path.realpath(os.path.dirname(global_config.noxfile)))
+        os.chdir(noxfile_parent_dir)
         return importlib.machinery.SourceFileLoader(
             "user_nox_module", global_config.noxfile
         ).load_module()
 
     except (VersionCheckFailed, InvalidVersionSpecifier) as error:
         logger.error(str(error))
+        return 2
+    except FileNotFoundError:
+        logger.error(f"noxfile.py not found in {noxfile_parent_dir!r}.")
         return 2
     except (IOError, OSError):
         logger.exception("Failed to load Noxfile {}".format(global_config.noxfile))

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -70,7 +70,9 @@ def load_nox_module(global_config: Namespace) -> Union[types.ModuleType, int]:
         logger.error(str(error))
         return 2
     except FileNotFoundError:
-        logger.error(f"noxfile.py not found in {noxfile_parent_dir!r}.")
+        logger.error(
+            f"Failed to load Noxfile {global_config.noxfile}, no such file exists."
+        )
         return 2
     except (IOError, OSError):
         logger.exception("Failed to load Noxfile {}".format(global_config.noxfile))

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -82,7 +82,9 @@ def test_load_nox_module_not_found(caplog, tmp_path):
     config = _options.options.namespace(noxfile=str(bogus_noxfile))
 
     assert tasks.load_nox_module(config) == 2
-    assert f"noxfile.py not found in {str(tmp_path)!r}" in caplog.text
+    assert (
+        f"Failed to load Noxfile {bogus_noxfile}, no such file exists." in caplog.text
+    )
 
 
 def test_load_nox_module_IOError(caplog):


### PR DESCRIPTION
#462 

Add a friendlier message on the specific case that user is calling
nox from within a directory with no noxfile.

Existing test for this case modified and two additional tests
added to ensure lower level errors are still handled further down.