### PR TITLE
Run Flynt to convert str.format to f-strings

### DIFF
--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -68,7 +68,7 @@ class Func(FunctionDecorator):
 class Call(Func):
     def __init__(self, func: Func, param_spec: "Param") -> None:
         call_spec = param_spec.call_spec
-        session_signature = "({})".format(param_spec)
+        session_signature = f"({param_spec})"
 
         # Determine the Python interpreter for the session using either @session
         # or @parametrize. For backwards compatibility, we only use a "python"

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -163,7 +163,7 @@ def make_flag_pair(
     The positive option is considered to be available to the noxfile, as
     there isn't much point in doing flag pairs without it.
     """
-    disable_name = "no_{}".format(name)
+    disable_name = f"no_{name}"
 
     kwargs["action"] = "store_true"
     enable_option = Option(
@@ -174,9 +174,7 @@ def make_flag_pair(
         **kwargs
     )
 
-    kwargs["help"] = "Disables {} if it is enabled in the Noxfile.".format(
-        enable_flags[-1]
-    )
+    kwargs["help"] = f"Disables {enable_flags[-1]} if it is enabled in the Noxfile."
     disable_option = Option(disable_name, *disable_flags, **kwargs)
 
     return enable_option, disable_option
@@ -285,7 +283,7 @@ class OptionSet:
         # used in tests.
         for key, value in kwargs.items():
             if key not in args:
-                raise KeyError("{} is not an option.".format(key))
+                raise KeyError(f"{key} is not an option.")
             args[key] = value
 
         return argparse.Namespace(**args)

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -85,7 +85,7 @@ class Option:
         default: Union[Any, Callable[[], Any]] = None,
         hidden: bool = False,
         completer: Optional[Callable[..., List[str]]] = None,
-        **kwargs: Any
+        **kwargs: Any,
     ) -> None:
         self.name = name
         self.flags = flags
@@ -156,7 +156,7 @@ def make_flag_pair(
     name: str,
     enable_flags: Union[Tuple[str, str], Tuple[str]],
     disable_flags: Tuple[str],
-    **kwargs: Any
+    **kwargs: Any,
 ) -> Tuple[Option, Option]:
     """Returns two options - one to enable a behavior and another to disable it.
 
@@ -171,7 +171,7 @@ def make_flag_pair(
         *enable_flags,
         noxfile=True,
         merge_func=functools.partial(flag_pair_merge_func, name, disable_name),
-        **kwargs
+        **kwargs,
     )
 
     kwargs["help"] = f"Disables {enable_flags[-1]} if it is enabled in the Noxfile."

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -197,14 +197,14 @@ def _posargs_finalizer(
     if "--" not in posargs:
         unexpected_posargs = posargs
         raise _option_set.ArgumentError(
-            None, "Unknown argument(s) '{}'.".format(" ".join(unexpected_posargs))
+            None, f"Unknown argument(s) '{' '.join(unexpected_posargs)}'."
         )
 
     dash_index = posargs.index("--")
     if dash_index != 0:
         unexpected_posargs = posargs[0:dash_index]
         raise _option_set.ArgumentError(
-            None, "Unknown argument(s) '{}'.".format(" ".join(unexpected_posargs))
+            None, f"Unknown argument(s) '{' '.join(unexpected_posargs)}'."
         )
 
     return posargs[dash_index + 1 :]

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -32,7 +32,7 @@ class Param:
         self,
         *args: Any,
         arg_names: Optional[Sequence[str]] = None,
-        id: Optional[str] = None
+        id: Optional[str] = None,
     ) -> None:
         self.args = tuple(args)
         self.id = id

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -51,7 +51,7 @@ class Param:
             return self.id
         else:
             call_spec = self.call_spec
-            args = ["{}={}".format(k, repr(call_spec[k])) for k in call_spec.keys()]
+            args = [f"{k}={repr(call_spec[k])}" for k in call_spec.keys()]
             return ", ".join(args)
 
     __repr__ = __str__

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -51,7 +51,7 @@ class Param:
             return self.id
         else:
             call_spec = self.call_spec
-            args = [f"{k}={repr(call_spec[k])}" for k in call_spec.keys()]
+            args = [f"{k}={call_spec[k]!r}" for k in call_spec.keys()]
             return ", ".join(args)
 
     __repr__ = __str__

--- a/nox/command.py
+++ b/nox/command.py
@@ -76,7 +76,7 @@ def run(
     success_codes: Optional[Iterable[int]] = None,
     log: bool = True,
     external: Union[Literal["error"], bool] = False,
-    **popen_kws: Any
+    **popen_kws: Any,
 ) -> Union[str, bool]:
     """Run a command-line program."""
 

--- a/nox/command.py
+++ b/nox/command.py
@@ -97,18 +97,14 @@ def run(
         if is_external_tool:
             if external == "error":
                 logger.error(
-                    "Error: {} is not installed into the virtualenv, it is located at {}. "
-                    "Pass external=True into run() to explicitly allow this.".format(
-                        cmd, cmd_path
-                    )
+                    f"Error: {cmd} is not installed into the virtualenv, it is located at {cmd_path}. "
+                    "Pass external=True into run() to explicitly allow this."
                 )
                 raise CommandFailed("External program disallowed.")
             elif external is False:
                 logger.warning(
-                    "Warning: {} is not installed into the virtualenv, it is located at {}. This might cause issues! "
-                    "Pass external=True into run() to silence this message.".format(
-                        cmd, cmd_path
-                    )
+                    f"Warning: {cmd} is not installed into the virtualenv, it is located at {cmd_path}. This might cause issues! "
+                    "Pass external=True into run() to silence this message."
                 )
 
     env = _clean_env(env)
@@ -119,10 +115,9 @@ def run(
         )
 
         if return_code not in success_codes:
+            suffix = ":" if silent else ""
             logger.error(
-                "Command {} failed with exit code {}{}".format(
-                    full_cmd, return_code, ":" if silent else ""
-                )
+                f"Command {full_cmd} failed with exit code {return_code}{suffix}"
             )
 
             if silent:

--- a/nox/command.py
+++ b/nox/command.py
@@ -50,8 +50,8 @@ def which(program: str, paths: Optional[List[str]]) -> str:
     if full_path:
         return full_path.strpath
 
-    logger.error("Program {} not found.".format(program))
-    raise CommandFailed("Program {} not found".format(program))
+    logger.error(f"Program {program} not found.")
+    raise CommandFailed(f"Program {program} not found")
 
 
 def _clean_env(env: Optional[dict]) -> Optional[dict]:
@@ -84,7 +84,7 @@ def run(
         success_codes = [0]
 
     cmd, args = args[0], args[1:]
-    full_cmd = "{} {}".format(cmd, " ".join(args))
+    full_cmd = f"{cmd} {' '.join(args)}"
 
     cmd_path = which(cmd, paths)
 
@@ -128,7 +128,7 @@ def run(
             if silent:
                 sys.stderr.write(output)
 
-            raise CommandFailed("Returned code {}".format(return_code))
+            raise CommandFailed(f"Returned code {return_code}")
 
         if output:
             logger.output(output)

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -260,9 +260,7 @@ class Manifest:
             if not multi:
                 long_names.append(f"{name}{call.session_signature}")
             if func.python:
-                long_names.append(
-                    f"{name}-{func.python}{call.session_signature}"
-                )
+                long_names.append(f"{name}-{func.python}{call.session_signature}")
                 # Ensure that specifying session-python will run all parameterizations.
                 long_names.append(f"{name}-{func.python}")
 

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -162,7 +162,7 @@ class Manifest:
             if _normalize_arg(session_name) not in all_sessions
         ]
         if missing_sessions:
-            raise KeyError("Sessions not found: {}".format(", ".join(missing_sessions)))
+            raise KeyError(f"Sessions not found: {', '.join(missing_sessions)}")
 
     def filter_by_python_interpreter(self, specified_pythons: Sequence[str]) -> None:
         """Filter sessions in the queue based on the user-specified
@@ -247,7 +247,7 @@ class Manifest:
             if not multi:
                 long_names.append(name)
             if func.python:
-                long_names.append("{}-{}".format(name, func.python))
+                long_names.append(f"{name}-{func.python}")
 
             return [SessionRunner(name, long_names, func, self._config, self)]
 
@@ -258,13 +258,13 @@ class Manifest:
         for call in calls:
             long_names = []
             if not multi:
-                long_names.append("{}{}".format(name, call.session_signature))
+                long_names.append(f"{name}{call.session_signature}")
             if func.python:
                 long_names.append(
-                    "{}-{}{}".format(name, func.python, call.session_signature)
+                    f"{name}-{func.python}{call.session_signature}"
                 )
                 # Ensure that specifying session-python will run all parameterizations.
-                long_names.append("{}-{}".format(name, func.python))
+                long_names.append(f"{name}-{func.python}")
 
             sessions.append(SessionRunner(name, long_names, call, self._config, self))
 
@@ -318,7 +318,7 @@ class Manifest:
                 return True
 
         # The session was not found in the list of sessions.
-        raise ValueError("Session {} not found.".format(session))
+        raise ValueError(f"Session {session} not found.")
 
 
 class KeywordLocals(collections.abc.Mapping):

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -89,9 +89,7 @@ def _dblquote_pkg_install_args(args: Tuple[str, ...]) -> Tuple[str, ...]:
             else:
                 # need to double-quote string
                 if '"' in pkg_req_str:
-                    raise ValueError(
-                        f"Cannot escape requirement string: {pkg_req_str}"
-                    )
+                    raise ValueError(f"Cannot escape requirement string: {pkg_req_str}")
                 return f'"{pkg_req_str}"'
         else:
             # no dangerous char: no need to double-quote string
@@ -410,7 +408,7 @@ class Session:
             *prefix_args,
             *args,
             external="error",
-            **kwargs
+            **kwargs,
         )
 
     def install(self, *args: str, **kwargs: Any) -> None:
@@ -614,9 +612,7 @@ class SessionRunner:
             raise
 
         except Exception as exc:
-            logger.exception(
-                f"Session {self.friendly_name} raised exception {exc!r}"
-            )
+            logger.exception(f"Session {self.friendly_name} raised exception {exc!r}")
             return Result(self, Status.FAILED)
 
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -79,7 +79,7 @@ def _dblquote_pkg_install_args(args: Tuple[str, ...]) -> Tuple[str, ...]:
         # sanity check: we need an even number of double-quotes
         if pkg_req_str.count('"') % 2 != 0:
             raise ValueError(
-                "ill-formated argument with odd number of quotes: %s" % pkg_req_str
+                f"ill-formated argument with odd number of quotes: {pkg_req_str}"
             )
 
         if "<" in pkg_req_str or ">" in pkg_req_str:
@@ -90,9 +90,9 @@ def _dblquote_pkg_install_args(args: Tuple[str, ...]) -> Tuple[str, ...]:
                 # need to double-quote string
                 if '"' in pkg_req_str:
                     raise ValueError(
-                        "Cannot escape requirement string: %s" % pkg_req_str
+                        f"Cannot escape requirement string: {pkg_req_str}"
                     )
-                return '"%s"' % pkg_req_str
+                return f'"{pkg_req_str}"'
         else:
             # no dangerous char: no need to double-quote string
             return pkg_req_str
@@ -193,7 +193,7 @@ class Session:
 
     def chdir(self, dir: Union[str, os.PathLike]) -> None:
         """Change the current working directory."""
-        self.log("cd {}".format(dir))
+        self.log(f"cd {dir}")
         os.chdir(dir)
 
     cd = chdir
@@ -203,11 +203,11 @@ class Session:
         self, func: Callable, args: Iterable[Any], kwargs: Mapping[str, Any]
     ) -> Any:
         """Legacy support for running a function through :func`run`."""
-        self.log("{}(args={!r}, kwargs={!r})".format(func, args, kwargs))
+        self.log(f"{func}(args={args!r}, kwargs={kwargs!r})")
         try:
             return func(*args, **kwargs)
         except Exception as e:
-            logger.exception("Function {!r} raised {!r}.".format(func, e))
+            logger.exception(f"Function {func!r} raised {e!r}.")
             raise nox.command.CommandFailed()
 
     def run(
@@ -263,7 +263,7 @@ class Session:
             raise ValueError("At least one argument required to run().")
 
         if self._runner.global_config.install_only:
-            logger.info("Skipping {} run, as --install-only is set.".format(args[0]))
+            logger.info(f"Skipping {args[0]} run, as --install-only is set.")
             return None
 
         return self._run(*args, env=env, **kwargs)
@@ -520,7 +520,7 @@ class SessionRunner:
 
     def __str__(self) -> str:
         sigs = ", ".join(self.signatures)
-        return "Session(name={}, signatures={})".format(self.name, sigs)
+        return f"Session(name={self.name}, signatures={sigs})"
 
     @property
     def friendly_name(self) -> str:
@@ -577,7 +577,7 @@ class SessionRunner:
         self.venv.create()
 
     def execute(self) -> "Result":
-        logger.warning("Running session {}".format(self.friendly_name))
+        logger.warning(f"Running session {self.friendly_name}")
 
         try:
             # By default, nox should quietly change to the directory where
@@ -610,12 +610,12 @@ class SessionRunner:
             return Result(self, Status.FAILED)
 
         except KeyboardInterrupt:
-            logger.error("Session {} interrupted.".format(self.friendly_name))
+            logger.error(f"Session {self.friendly_name} interrupted.")
             raise
 
         except Exception as exc:
             logger.exception(
-                "Session {} raised exception {!r}".format(self.friendly_name, exc)
+                f"Session {self.friendly_name} raised exception {exc!r}"
             )
             return Result(self, Status.FAILED)
 
@@ -655,7 +655,7 @@ class Result:
             return "was successful"
         status = self.status.name.lower()
         if self.reason:
-            return "{}: {}".format(status, self.reason)
+            return f"{status}: {self.reason}"
         else:
             return status
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -63,9 +63,9 @@ def _normalize_path(envdir: str, path: Union[str, bytes]) -> str:
             logger.warning("The virtualenv name was hashed to avoid being too long.")
         else:
             logger.error(
-                "The virtualenv path {} is too long and will cause issues on "
+                f"The virtualenv path {full_path} is too long and will cause issues on "
                 "some environments. Use the --envdir path to modify where "
-                "nox stores virtualenvs.".format(full_path)
+                "nox stores virtualenvs."
             )
 
     return full_path
@@ -567,9 +567,7 @@ class SessionRunner:
             )
         else:
             raise ValueError(
-                "Expected venv_backend one of ('virtualenv', 'conda', 'venv'), but got '{}'.".format(
-                    backend
-                )
+                f"Expected venv_backend one of ('virtualenv', 'conda', 'venv'), but got '{backend}'."
             )
 
         self.venv.create()

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -255,9 +255,7 @@ def run_manifest(manifest: Manifest, global_config: Namespace) -> List[Result]:
             )
 
         result = session.execute()
-        result.log(
-            f"Session {session.friendly_name} {result.imperfect}."
-        )
+        result.log(f"Session {session.friendly_name} {result.imperfect}.")
         results.append(result)
 
         # Sanity check: If we are supposed to stop on the first error case,
@@ -288,9 +286,7 @@ def print_summary(results: List[Result], global_config: Namespace) -> List[Resul
     # human-readable way.
     logger.warning("Ran multiple sessions:")
     for result in results:
-        result.log(
-            f"* {result.session.friendly_name}: {result.status.name.lower()}"
-        )
+        result.log(f"* {result.session.friendly_name}: {result.status.name.lower()}")
 
     # Return the results that were sent to this function.
     return results

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -209,9 +209,7 @@ def honor_list_request(
         )
 
     print(
-        "\nsessions marked with {selected_color}*{reset} are selected, sessions marked with {skipped_color}-{reset} are skipped.".format(
-            selected_color=selected_color, skipped_color=skipped_color, reset=reset
-        )
+        f"\nsessions marked with {selected_color}*{reset} are selected, sessions marked with {skipped_color}-{reset} are skipped."
     )
     return 0
 
@@ -255,9 +253,8 @@ def run_manifest(manifest: Manifest, global_config: Namespace) -> List[Result]:
         # possibly raise warnings associated with this session
         if WARN_PYTHONS_IGNORED in session.func.should_warn:
             logger.warning(
-                "Session {} is set to run with venv_backend='none', IGNORING its python={} parametrization. ".format(
-                    session.name, session.func.should_warn[WARN_PYTHONS_IGNORED]
-                )
+                f"Session {session.name} is set to run with venv_backend='none', "
+                f"IGNORING its python={session.func.should_warn[WARN_PYTHONS_IGNORED]} parametrization. "
             )
 
         result = session.execute()

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -69,7 +69,7 @@ def load_nox_module(global_config: Namespace) -> Union[types.ModuleType, int]:
         logger.error(str(error))
         return 2
     except (IOError, OSError):
-        logger.exception("Failed to load Noxfile {}".format(global_config.noxfile))
+        logger.exception(f"Failed to load Noxfile {global_config.noxfile}")
         return 2
 
 
@@ -173,7 +173,7 @@ def honor_list_request(
     if manifest.module_docstring:
         print(manifest.module_docstring.strip(), end="\n\n")
 
-    print("Sessions defined in {noxfile}:\n".format(noxfile=global_config.noxfile))
+    print(f"Sessions defined in {global_config.noxfile}:\n")
 
     reset = parse_colors("reset") if global_config.color else ""
     selected_color = parse_colors("cyan") if global_config.color else ""
@@ -256,9 +256,7 @@ def run_manifest(manifest: Manifest, global_config: Namespace) -> List[Result]:
 
         result = session.execute()
         result.log(
-            "Session {name} {status}.".format(
-                name=session.friendly_name, status=result.imperfect
-            )
+            f"Session {session.friendly_name} {result.imperfect}."
         )
         results.append(result)
 
@@ -291,9 +289,7 @@ def print_summary(results: List[Result], global_config: Namespace) -> List[Resul
     logger.warning("Ran multiple sessions:")
     for result in results:
         result.log(
-            "* {name}: {status}".format(
-                name=result.session.friendly_name, status=result.status.name.lower()
-            )
+            f"* {result.session.friendly_name}: {result.status.name.lower()}"
         )
 
     # Return the results that were sent to this function.

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -261,7 +261,9 @@ def run_manifest(manifest: Manifest, global_config: Namespace) -> List[Result]:
             )
 
         result = session.execute()
-        result.log(f"Session {session.friendly_name} {result.imperfect}.")
+        name = session.friendly_name
+        status = result.imperfect
+        result.log(f"Session {name} {status}.")
         results.append(result)
 
         # Sanity check: If we are supposed to stop on the first error case,
@@ -292,7 +294,9 @@ def print_summary(results: List[Result], global_config: Namespace) -> List[Resul
     # human-readable way.
     logger.warning("Ran multiple sessions:")
     for result in results:
-        result.log(f"* {result.session.friendly_name}: {result.status.name.lower()}")
+        name = result.session.friendly_name
+        status = result.status.name.lower()
+        result.log(f"* {name}: {status}")
 
     # Return the results that were sent to this function.
     return results

--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -29,7 +29,7 @@ _TEMPLATE = jinja2.Template(
 
 
 def wrapjoin(seq: Iterator[Any]) -> str:
-    return ", ".join(["'{}'".format(item) for item in seq])
+    return ", ".join([f"'{item}'" for item in seq])
 
 
 def main() -> None:

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -460,12 +460,10 @@ class VirtualEnv(ProcessEnv):
             cmd = [self._resolved_interpreter, "-m", "venv", self.location]
         cmd.extend(self.venv_params)
 
+        resolved_interpreter_name = os.path.basename(self._resolved_interpreter)
+
         logger.info(
-            "Creating virtual environment ({}) using {} in {}".format(
-                self.venv_or_virtualenv,
-                os.path.basename(self._resolved_interpreter),
-                self.location_name,
-            )
+            f"Creating virtual environment ({self.venv_or_virtualenv}) using {resolved_interpreter_name} in {self.location_name}"
         )
         nox.command.run(cmd, silent=True, log=False)
 

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -38,7 +38,7 @@ _ENABLE_STALENESS_CHECK = "NOX_ENABLE_STALENESS_CHECK" in os.environ
 
 class InterpreterNotFound(OSError):
     def __init__(self, interpreter: str) -> None:
-        super().__init__("Python interpreter {} not found".format(interpreter))
+        super().__init__(f"Python interpreter {interpreter} not found")
         self.interpreter = interpreter
 
 
@@ -138,7 +138,7 @@ def locate_using_path_and_version(version: str) -> Optional[str]:
     path_python = py.path.local.sysfind("python")
     if path_python:
         try:
-            prefix = "{}.".format(version)
+            prefix = f"{version}."
             version_string = path_python.sysexec("-c", script).strip()
             if version_string.startswith(prefix):
                 return str(path_python)
@@ -227,7 +227,7 @@ class CondaEnv(ProcessEnv):
         """Create the conda env."""
         if not self._clean_location():
             logger.debug(
-                "Re-using existing conda env at {}.".format(self.location_name)
+                f"Re-using existing conda env at {self.location_name}."
             )
 
             self._reused = True
@@ -242,13 +242,13 @@ class CondaEnv(ProcessEnv):
         cmd.append("pip")
 
         if self.interpreter:
-            python_dep = "python={}".format(self.interpreter)
+            python_dep = f"python={self.interpreter}"
         else:
             python_dep = "python"
         cmd.append(python_dep)
 
         logger.info(
-            "Creating conda env in {} with {}".format(self.location_name, python_dep)
+            f"Creating conda env in {self.location_name} with {python_dep}"
         )
         nox.command.run(cmd, silent=True, log=False)
 
@@ -402,7 +402,7 @@ class VirtualEnv(ProcessEnv):
         match = re.match(r"^(?P<xy_ver>\d(\.\d+)?)(\.\d+)?$", self.interpreter)
         if match:
             xy_version = match.group("xy_ver")
-            cleaned_interpreter = "python{}".format(xy_version)
+            cleaned_interpreter = f"python{xy_version}"
 
         # If the cleaned interpreter is on the PATH, go ahead and return it.
         if py.path.local.sysfind(cleaned_interpreter):
@@ -449,9 +449,7 @@ class VirtualEnv(ProcessEnv):
         """Create the virtualenv or venv."""
         if not self._clean_location():
             logger.debug(
-                "Re-using existing virtual environment at {}.".format(
-                    self.location_name
-                )
+                f"Re-using existing virtual environment at {self.location_name}."
             )
 
             self._reused = True

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -226,9 +226,7 @@ class CondaEnv(ProcessEnv):
     def create(self) -> bool:
         """Create the conda env."""
         if not self._clean_location():
-            logger.debug(
-                f"Re-using existing conda env at {self.location_name}."
-            )
+            logger.debug(f"Re-using existing conda env at {self.location_name}.")
 
             self._reused = True
 
@@ -247,9 +245,7 @@ class CondaEnv(ProcessEnv):
             python_dep = "python"
         cmd.append(python_dep)
 
-        logger.info(
-            f"Creating conda env in {self.location_name} with {python_dep}"
-        )
+        logger.info(f"Creating conda env in {self.location_name} with {python_dep}")
         nox.command.run(cmd, silent=True, log=False)
 
         return True

--- a/noxfile.py
+++ b/noxfile.py
@@ -47,7 +47,7 @@ def tests(session):
         ".coveragerc",
         "--cov-report=",
         *tests,
-        env={"COVERAGE_FILE": f".coverage.{session.python}"}
+        env={"COVERAGE_FILE": f".coverage.{session.python}"},
     )
     session.notify("cover")
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -47,7 +47,7 @@ def tests(session):
         ".coveragerc",
         "--cov-report=",
         *tests,
-        env={"COVERAGE_FILE": ".coverage.{}".format(session.python)}
+        env={"COVERAGE_FILE": f".coverage.{session.python}"}
     )
     session.notify("cover")
 

--- a/tests/resources/noxfile_nested.py
+++ b/tests/resources/noxfile_nested.py
@@ -18,4 +18,4 @@ import nox
 @nox.session(py=False)
 @nox.parametrize("cheese", ["cheddar", "jack", "brie"])
 def snack(unused_session, cheese):
-    print("Noms, {} so good!".format(cheese))
+    print(f"Noms, {cheese} so good!")

--- a/tests/resources/noxfile_pythons.py
+++ b/tests/resources/noxfile_pythons.py
@@ -4,4 +4,4 @@ import nox
 @nox.session(python=["3.6"])
 @nox.parametrize("cheese", ["cheddar", "jack", "brie"])
 def snack(unused_session, cheese):
-    print("Noms, {} so good!".format(cheese))
+    print(f"Noms, {cheese} so good!")

--- a/tests/resources/noxfile_spaces.py
+++ b/tests/resources/noxfile_spaces.py
@@ -18,4 +18,4 @@ import nox
 @nox.session(py=False, name="cheese list")
 @nox.parametrize("cheese", ["cheddar", "jack", "brie"])
 def snack(unused_session, cheese):
-    print("Noms, {} so good!".format(cheese))
+    print(f"Noms, {cheese} so good!")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -542,8 +542,8 @@ def generate_noxfile_options_pythons(tmp_path):
     return generate_noxfile
 
 
-python_current_version = "{}.{}".format(sys.version_info.major, sys.version_info.minor)
-python_next_version = "{}.{}".format(sys.version_info.major, sys.version_info.minor + 1)
+python_current_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+python_next_version = f"{sys.version_info.major}.{sys.version_info.minor + 1}"
 
 
 def test_main_noxfile_options_with_pythons_override(
@@ -566,7 +566,7 @@ def test_main_noxfile_options_with_pythons_override(
 
     for python_version in [python_current_version, python_next_version]:
         for session in ["test", "launch_rocket"]:
-            line = "Running session {}-{}".format(session, python_version)
+            line = f"Running session {session}-{python_version}"
             if session == "test" and python_version == python_current_version:
                 assert line in stderr
             else:
@@ -593,7 +593,7 @@ def test_main_noxfile_options_with_sessions_override(
 
     for python_version in [python_current_version, python_next_version]:
         for session in ["test", "launch_rocket"]:
-            line = "Running session {}-{}".format(session, python_version)
+            line = f"Running session {session}-{python_version}"
             if session == "launch_rocket" and python_version == python_current_version:
                 assert line in stderr
             else:

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -450,7 +450,7 @@ class TestSession:
             pkg_requirement = passed_arg = "urllib3"
         elif version_constraint == "yes":
             pkg_requirement = "urllib3<1.25"
-            passed_arg = '"%s"' % pkg_requirement
+            passed_arg = f'"{pkg_requirement}"'
         elif version_constraint == "already_dbl_quoted":
             pkg_requirement = passed_arg = '"urllib3<1.25"'
         else:


### PR DESCRIPTION
I didn't file an Issue for this one because this is very much down to personal developer preference, so feel free to reject this if you don't want it I won't be offended at all! :)

Things like this would be very tedious to do by hand but I discovered an automated tool [Flynt](https://github.com/ikamensh/flynt) to convert the older style `"{}".format()` strings with newer `f"{}"` style strings and it seems to have worked great!

Since 3.5 is now EOL, it might make sense to convert to the new format!