### PR TITLE
Conda logs now respect nox.options.verbose.

### DIFF
--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -22,6 +22,7 @@ from typing import Any, List, Mapping, Optional, Tuple, Union
 
 import py
 
+import nox
 import nox.command
 from nox.logger import logger
 
@@ -250,7 +251,7 @@ class CondaEnv(ProcessEnv):
         logger.info(
             "Creating conda env in {} with {}".format(self.location_name, python_dep)
         )
-        nox.command.run(cmd, silent=True, log=False)
+        nox.command.run(cmd, silent=True, log=nox.options.verbose or False)
 
         return True
 
@@ -473,6 +474,6 @@ class VirtualEnv(ProcessEnv):
                 self.location_name,
             )
         )
-        nox.command.run(cmd, silent=True, log=False)
+        nox.command.run(cmd, silent=True, log=nox.options.verbose or False)
 
         return True

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -210,6 +210,23 @@ def test_condaenv_create_interpreter(make_conda):
         assert dir_.join("bin", "python3.7").check()
 
 
+@pytest.mark.skipif(not HAS_CONDA, reason="Missing conda command.")
+def test_conda_env_create_verbose(make_conda):
+    venv, dir_ = make_conda()
+    with mock.patch("nox.virtualenv.nox.command.run") as mock_run:
+        venv.create()
+
+    args, kwargs = mock_run.call_args
+    assert kwargs["log"] is False
+
+    nox.options.verbose = True
+    with mock.patch("nox.virtualenv.nox.command.run") as mock_run:
+        venv.create()
+
+    args, kwargs = mock_run.call_args
+    assert kwargs["log"]
+
+
 @mock.patch("nox.virtualenv._SYSTEM", new="Windows")
 def test_condaenv_bin_windows(make_conda):
     venv, dir_ = make_conda()


### PR DESCRIPTION
Fixes #345 

First pass at this, I basically just copied the implementation from #371.