### PR TITLE
Enable the sessions to access the original cwd

### DIFF
--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -44,6 +44,9 @@ def load_nox_module(global_config: Namespace) -> Union[types.ModuleType, int]:
     Returns:
         module: The module designated by the Noxfile path.
     """
+    # save the original cwd, if the session wants to
+    # use it instead of giving the choice to Nox.
+    global_config.original_cwd = os.getcwd()
     try:
         # Save the absolute path to the Noxfile.
         # This will inoculate it if nox changes paths because of an implicit


### PR DESCRIPTION
Closes #469. Store the original cwd inside `global_config`, and then enable the sessions to get access to it.

CC @theacodes