### PR TITLE
Add python 3.10.0-rc2 to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019]
-        python-version: [3.6, 3.7, 3.8, "3.10.0-rc.2"]
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
@@ -23,6 +23,27 @@ jobs:
           python -m pip install --disable-pip-version-check .
       - name: Run tests on ${{ matrix.os }}
         run: nox --non-interactive --session "tests-${{ matrix.python-version }}" -- --full-trace
+
+  build-py310:
+    name: Build python 3.10
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019]
+        python-version: ["3.10.0-rc.2"]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      # Conda does not support 3.10 yet, hence why it's skipped here
+      - name: Install Nox-under-test
+        run: |
+          python -m pip install --disable-pip-version-check .
+      - name: Run tests on ${{ matrix.os }}
+        run: nox --non-interactive --session "tests-${{ matrix.python-version }}" -- --full-trace
+
   lint:
     runs-on: ubuntu-20.04
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,7 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       # Conda does not support 3.10 yet, hence why it's skipped here
+      # TODO: Merge the two build jobs when 3.10 is released for conda
       - name: Install Nox-under-test
         run: |
           python -m pip install --disable-pip-version-check .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019]
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.6, 3.7, 3.8, "3.10.0-rc.2"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -105,7 +105,7 @@ def lint(session):
     session.run("flake8", *files)
 
 
-@nox.session(python="3.7")
+@nox.session(python="3.8")
 def docs(session):
     """Build the documentation."""
     output_dir = os.path.join(session.create_tmp(), "output")

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,7 +30,9 @@ def is_python_version(session, version):
     return py_version.startswith(version)
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"])
+# TODO: When 3.10 is released, change the version below to 3.10
+# this is here so GitHub actions can pick up on the session name
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10.0-rc.2"])
 def tests(session):
     """Run test suite with pytest."""
     session.create_tmp()


### PR DESCRIPTION
Closes #474 

This PR adds `python 3.10.0-rc2` to `ci.yml` so it will be run as part of the standard CI suite.

I also noticed that the docs action specified python 3.8 but the docs session in `noxfile.py` specified 3.7 causing the docs session to just skip and therefore pass CI without actually building the docs, which I assume is not what we want so I've changed the docs session to python 3.8 in ` noxfile.py` to bring it in line with the other sessions that specify a python.

This is all passing locally and on my forks CI. Let me know if anyone wants anything else as part of this 👍🏻 