### PR TITLE
CI: Python 3.10.0-rc.2 coverage fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check .
       - name: Run tests on ${{ matrix.os }}
-        run: nox --non-interactive --session "tests-${{ matrix.python-version }}" -- --full-trace
+        run: nox --non-interactive --session "tests-${{ matrix.python-version }}" "cover-${{ matrix.python-version }}" -- --full-trace
 
   build-py310:
     name: Build python 3.10
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check .
       - name: Run tests on ${{ matrix.os }}
-        run: nox --non-interactive --session "tests-3.10" -- --full-trace
+        run: nox --non-interactive --session "tests-3.10" "cover-3.10" -- --full-trace
 
   lint:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: "3.10.0-rc.2"
       # Conda does not support 3.10 yet, hence why it's skipped here
       # TODO: Merge the two build jobs when 3.10 is released for conda
       - name: Install Nox-under-test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check .
       - name: Run tests on ${{ matrix.os }}
-        run: nox --non-interactive --session "tests-${{ matrix.python-version }}" "cover" -- --full-trace
+        run: nox --non-interactive --session "tests-${{ matrix.python-version }}" -- --full-trace
 
   build-py310:
     name: Build python 3.10
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check .
       - name: Run tests on ${{ matrix.os }}
-        run: nox --non-interactive --session "tests-3.10" "cover" -- --full-trace
+        run: nox --non-interactive --session "tests-3.10" -- --full-trace
 
   lint:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check .
       - name: Run tests on ${{ matrix.os }}
-        run: nox --non-interactive --session "tests-${{ matrix.python-version }}" "cover-${{ matrix.python-version }}" -- --full-trace
+        run: nox --non-interactive --session "tests-${{ matrix.python-version }}" "cover" -- --full-trace
 
   build-py310:
     name: Build python 3.10
@@ -42,7 +42,7 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check .
       - name: Run tests on ${{ matrix.os }}
-        run: nox --non-interactive --session "tests-3.10" "cover-3.10" -- --full-trace
+        run: nox --non-interactive --session "tests-3.10" "cover" -- --full-trace
 
   lint:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,20 +30,19 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-20.04, windows-2019]
-        python-version: ["3.10.0-rc.2"]
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: "3.10"
       # Conda does not support 3.10 yet, hence why it's skipped here
       # TODO: Merge the two build jobs when 3.10 is released for conda
       - name: Install Nox-under-test
         run: |
           python -m pip install --disable-pip-version-check .
       - name: Run tests on ${{ matrix.os }}
-        run: nox --non-interactive --session "tests-${{ matrix.python-version }}" -- --full-trace
+        run: nox --non-interactive --session "tests-3.10" -- --full-trace
 
   lint:
     runs-on: ubuntu-20.04

--- a/noxfile.py
+++ b/noxfile.py
@@ -30,9 +30,7 @@ def is_python_version(session, version):
     return py_version.startswith(version)
 
 
-# TODO: When 3.10 is released, change the version below to 3.10
-# this is here so GitHub actions can pick up on the session name
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10.0-rc.2"])
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
 def tests(session):
     """Run test suite with pytest."""
     session.create_tmp()
@@ -54,6 +52,7 @@ def tests(session):
     session.notify("cover")
 
 
+# TODO: When conda supports 3.10 on GHA, add here too
 @nox.session(python=["3.6", "3.7", "3.8", "3.9"], venv_backend="conda")
 def conda_tests(session):
     """Run test suite with pytest."""

--- a/noxfile.py
+++ b/noxfile.py
@@ -16,6 +16,7 @@
 import functools
 import os
 import platform
+import sys
 
 import nox
 
@@ -65,7 +66,7 @@ def conda_tests(session):
     session.run("pytest", *tests)
 
 
-@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
+@nox.session
 def cover(session):
     """Coverage analysis."""
     if ON_WINDOWS_CI:
@@ -73,7 +74,10 @@ def cover(session):
 
     # 3.10 produces different coverage results for some reason
     # see https://github.com/theacodes/nox/issues/478
-    fail_under = 99 if is_python_version(session, "3.10.0") else 100
+    fail_under = 100
+    py_version = sys.version_info
+    if py_version.major == 3 and py_version.minor == 10:
+        fail_under = 99
 
     session.install("coverage")
     session.run("coverage", "combine")

--- a/noxfile.py
+++ b/noxfile.py
@@ -65,15 +65,19 @@ def conda_tests(session):
     session.run("pytest", *tests)
 
 
-@nox.session
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"])
 def cover(session):
     """Coverage analysis."""
     if ON_WINDOWS_CI:
         return
 
+    # 3.10 produces different coverage results for some reason
+    # see https://github.com/theacodes/nox/issues/478
+    fail_under = 99 if is_python_version(session, "3.10.0") else 100
+
     session.install("coverage")
     session.run("coverage", "combine")
-    session.run("coverage", "report", "--fail-under=100", "--show-missing")
+    session.run("coverage", "report", f"--fail-under={fail_under}", "--show-missing")
     session.run("coverage", "erase")
 
 

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -85,7 +85,7 @@ class TestOptionSet:
         )
         # if noxfile.py changes, this will have to change as well since these are
         # some of the actual sessions found in noxfile.py
-        some_expected_sessions = ["cover", "blacken", "lint", "docs"]
+        some_expected_sessions = ["blacken", "lint", "docs"]
         assert len(set(some_expected_sessions) - set(all_nox_sessions)) == 0
 
     def test_session_completer_invalid_sessions(self):


### PR DESCRIPTION
Closes #478 

After some playing around with my fork I've managed to get tests and coverage playing nicely on 3.10.

Summary of changes:

- Detect when we're running on 3.10 and reduce coverage fail under to 99 from 100
- Parametrise `cover` with the same pythons as `tests` so I could access `session.python` to do the above
- Explicitly call `cover-<version`> in the Github Actions workflow (`session.notify` didn't seem to work for me here, I tried both `"cover"` and `"cover-<version>"` as arguments with no luck, if anyone knows how to fix this it would clean this solution up a little bit)

I did also notice that one of the tests (`test_session_completer`) was coupled to the noxfile. I didn't look into it too much but I think we should look at decoupling if possible as then we're free to change the noxfile however we want without altering test behaviour