### PR TITLE
Decouple `test_session_completer` from project level noxfile

### DIFF
--- a/tests/resources/noxfile_multiple_sessions.py
+++ b/tests/resources/noxfile_multiple_sessions.py
@@ -1,0 +1,33 @@
+# Copyright 2018 Alethea Katherine Flowers
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import nox
+
+# Deliberately giving these silly names so we know this is not confused
+# with the projects noxfile
+
+
+@nox.session
+def testytest(session):
+    session.log("Testing")
+
+
+@nox.session
+def lintylint(session):
+    session.log("Linting")
+
+
+@nox.session
+def typeytype(session):
+    session.log("Type Checking")

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -12,12 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from pathlib import Path
+
 import pytest
 
 from nox import _option_set, _options
 
 # The vast majority of _option_set is tested by test_main, but the test helper
 # :func:`OptionSet.namespace` needs a bit of help to get to full coverage.
+
+
+RESOURCES = Path(__file__).parent.joinpath("resources")
 
 
 class TestOptionSet:
@@ -79,14 +84,17 @@ class TestOptionSet:
             optionset.parser()
 
     def test_session_completer(self):
-        parsed_args = _options.options.namespace(sessions=(), keywords=(), posargs=[])
+        parsed_args = _options.options.namespace(
+            sessions=("testytest", "lintylint", "typeytype"),
+            posargs=[],
+            noxfile=str(RESOURCES.joinpath("noxfile_multiple_sessions.py")),
+        )
         all_nox_sessions = _options._session_completer(
             prefix=None, parsed_args=parsed_args
         )
-        # if noxfile.py changes, this will have to change as well since these are
-        # some of the actual sessions found in noxfile.py
-        some_expected_sessions = ["blacken", "lint", "docs"]
-        assert len(set(some_expected_sessions) - set(all_nox_sessions)) == 0
+
+        some_expected_sessions = ["testytest", "lintylint", "typeytype"]
+        assert some_expected_sessions == all_nox_sessions
 
     def test_session_completer_invalid_sessions(self):
         parsed_args = _options.options.namespace(

--- a/tests/test__option_set.py
+++ b/tests/test__option_set.py
@@ -85,16 +85,15 @@ class TestOptionSet:
 
     def test_session_completer(self):
         parsed_args = _options.options.namespace(
-            sessions=("testytest", "lintylint", "typeytype"),
             posargs=[],
             noxfile=str(RESOURCES.joinpath("noxfile_multiple_sessions.py")),
         )
-        all_nox_sessions = _options._session_completer(
+        actual_sessions_from_file = _options._session_completer(
             prefix=None, parsed_args=parsed_args
         )
 
-        some_expected_sessions = ["testytest", "lintylint", "typeytype"]
-        assert some_expected_sessions == all_nox_sessions
+        expected_sessions = ["testytest", "lintylint", "typeytype"]
+        assert expected_sessions == actual_sessions_from_file
 
     def test_session_completer_invalid_sessions(self):
         parsed_args = _options.options.namespace(


### PR DESCRIPTION
Didn't raise an issue for this because it was discussed here: https://github.com/theacodes/nox/pull/479#issuecomment-920673738

This PR decouples `test_session_completer` from the project's actual noxfile by adding a new fake noxfile with multiple sessions under `tests/resources` and pointing `test_session_completer` at it using the keyword argument.