### PR TITLE
Add `session.warn` to output warnings

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -516,6 +516,10 @@ class Session:
         """Outputs a log during the session."""
         logger.info(*args, **kwargs)
 
+    def warn(self, *args: Any, **kwargs: Any) -> None:
+        """Outputs a warning during the session."""
+        logger.warning(*args, **kwargs)
+
     def error(self, *args: Any) -> "_typing.NoReturn":
         """Immediately aborts the session and optionally logs an error."""
         raise _SessionQuit(*args)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -600,7 +600,7 @@ class TestSession:
         session.log("meep")
 
         assert "meep" in caplog.text
-    
+
     def test_warn(self, caplog):
         caplog.set_level(logging.WARNING)
         session, _ = self.make_session_and_runner()

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -600,6 +600,14 @@ class TestSession:
         session.log("meep")
 
         assert "meep" in caplog.text
+    
+    def test_warn(self, caplog):
+        caplog.set_level(logging.WARNING)
+        session, _ = self.make_session_and_runner()
+        
+        session.warn("meep")
+        
+        assert "meep" in caplog.text
 
     def test_error(self, caplog):
         caplog.set_level(logging.ERROR)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -604,9 +604,9 @@ class TestSession:
     def test_warn(self, caplog):
         caplog.set_level(logging.WARNING)
         session, _ = self.make_session_and_runner()
-        
+
         session.warn("meep")
-        
+
         assert "meep" in caplog.text
 
     def test_error(self, caplog):


### PR DESCRIPTION
Closes #481. Create `session.warn` to show warnings during the session.

cc @theacodes @FollowTheProcess