### PR TITLE
Add `session.debug` to show debug-level messages

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -520,6 +520,10 @@ class Session:
         """Outputs a warning during the session."""
         logger.warning(*args, **kwargs)
 
+    def debug(self, *args: Any, **kwargs: Any) -> None:
+        """Outputs a debug-level message during the session."""
+        logger.debug(*args, **kwargs)
+
     def error(self, *args: Any) -> "_typing.NoReturn":
         """Immediately aborts the session and optionally logs an error."""
         raise _SessionQuit(*args)

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -609,6 +609,14 @@ class TestSession:
 
         assert "meep" in caplog.text
 
+    def test_debug(self, caplog):
+        caplog.set_level(logging.DEBUG)
+        session, _ = self.make_session_and_runner()
+
+        session.debug("meep")
+
+        assert "meep" in caplog.text
+
     def test_error(self, caplog):
         caplog.set_level(logging.ERROR)
         session, _ = self.make_session_and_runner()


### PR DESCRIPTION
Closes #485. A logging function to show debug-level messages.