### PR TITLE
Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10.0-rc.2"
+          python-version: "3.10"
       # Conda does not support 3.10 yet, hence why it's skipped here
       # TODO: Merge the two build jobs when 3.10 is released for conda
       - name: Install Nox-under-test

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Software Development :: Testing
 keywords = testing automation tox
 project_urls =


### PR DESCRIPTION
This PR changes "3.10.0-rc.2" to "3.10.0" in GitHub Actions now that 3.10 is officially released. I've also added the 3.10 pypi classifier in setup.cfg.

As far as I know conda does not yet support 3.10 so unfortunately we can't combine the testing action just yet!