### PR TITLE
Remove LICENSE from the manifest file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,2 @@
-include LICENSE
 recursive-include nox *.jinja2
 include nox/py.typed


### PR DESCRIPTION
Closes #504. The removed inclusion was redundant, since we use setuptools>=42.