### PR TITLE
Improvements to our noxfile

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -240,13 +240,13 @@ htmlhelp_basename = "noxdoc"
 
 latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
-    #'papersize': 'letterpaper',
+    # 'papersize': 'letterpaper',
     # The font size ('10pt', '11pt' or '12pt').
-    #'pointsize': '10pt',
+    # 'pointsize': '10pt',
     # Additional stuff for the LaTeX preamble.
-    #'preamble': '',
+    # 'preamble': '',
     # Latex figure (float) alignment
-    #'figure_align': 'htbp',
+    # 'figure_align': 'htbp',
 }
 
 # Grouping the document tree into LaTeX files. List of tuples

--- a/noxfile.py
+++ b/noxfile.py
@@ -53,8 +53,7 @@ def tests(session):
     session.notify("cover")
 
 
-# TODO: When conda supports 3.10 on GHA, add here too
-@nox.session(python=["3.6", "3.7", "3.8", "3.9"], venv_backend="conda")
+@nox.session(python=["3.6", "3.7", "3.8", "3.9", "3.10"], venv_backend="conda")
 def conda_tests(session):
     """Run test suite with pytest."""
     session.create_tmp()
@@ -106,7 +105,7 @@ def lint(session):
         "importlib_metadata",
     )
     session.run("mypy")
-    files = ["nox", "tests", "noxfile.py"]
+    files = ["nox", "tests", "noxfile.py", "docs/conf.py"]
     session.run("black", "--check", *files)
     session.run("isort", "--check", *files)
     session.run("flake8", *files)


### PR DESCRIPTION
Changes:

- Add Python 3.10 to our `conda_test` session, since GHA already supports Conda (see #501).

- Add `docs/conf.py` to the files where session `lint` will run, to be the same than the `blacken` step (see #499).