### PR TITLE
Add a 'cwd' keyword argument to the Session.run API

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -175,7 +175,7 @@ If you want to pass more arguments to a program just add more arguments to ``run
         session.run("pytest", "-v", "tests")
 
 
-You can also pass environment variables:
+You can also pass environment variables or select a working directory:
 
 .. code-block:: python
 
@@ -187,6 +187,7 @@ You can also pass environment variables:
             env={
                 "FLASK_DEBUG": "1"
             }
+            cwd="some/directory"
         )
 
 See :func:`nox.sessions.Session.run` for more options and examples for running

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -14,6 +14,7 @@
 
 import contextlib
 import locale
+import os
 import subprocess
 import sys
 from typing import IO, Mapping, Optional, Sequence, Tuple, Union
@@ -55,6 +56,7 @@ def decode_output(output: bytes) -> str:
 def popen(
     args: Sequence[str],
     env: Optional[Mapping[str, str]] = None,
+    cwd: Optional[Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]] = None,
     silent: bool = False,
     stdout: Optional[Union[int, IO]] = None,
     stderr: Union[int, IO] = subprocess.STDOUT,
@@ -67,7 +69,7 @@ def popen(
     if silent:
         stdout = subprocess.PIPE
 
-    proc = subprocess.Popen(args, env=env, stdout=stdout, stderr=stderr)
+    proc = subprocess.Popen(args, env=env, cwd=cwd, stdout=stdout, stderr=stderr)
 
     try:
         out, err = proc.communicate()

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -229,7 +229,8 @@ class Session:
             raise nox.command.CommandFailed()
 
     def run(
-        self, *args: str, env: Optional[Mapping[str, str]] = None, **kwargs: Any
+        self, *args: str, env: Optional[Mapping[str, str]] = None,
+        cwd: Optional[Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]] = None, **kwargs: Any
     ) -> Optional[Any]:
         """Run a command.
 
@@ -249,6 +250,12 @@ class Session:
                 'bash', '-c', 'echo $SOME_ENV',
                 env={'SOME_ENV': 'Hello'})
 
+        or run the command from within a specific working directory::
+
+            session.run(
+                'bash', '-c', 'pwd',
+                cwd='..')
+
         You can also tell nox to treat non-zero exit codes as success using
         ``success_codes``. For example, if you wanted to treat the ``pytest``
         "tests discovered, but none selected" error as success::
@@ -265,6 +272,8 @@ class Session:
         :param env: A dictionary of environment variables to expose to the
             command. By default, all environment variables are passed.
         :type env: dict or None
+        :param cwd: A :ref:`path-like` object to run the command from.
+        :type cwd: str, pathlib.Path or None
         :param bool silent: Silence command output, unless the command fails.
             ``False`` by default.
         :param success_codes: A list of return codes that are considered
@@ -287,7 +296,10 @@ class Session:
         return self._run(*args, env=env, **kwargs)
 
     def run_always(
-        self, *args: str, env: Optional[Mapping[str, str]] = None, **kwargs: Any
+        self, *args: str,
+        env: Optional[Mapping[str, str]] = None,
+        cwd: Optional[Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]] = None,
+            **kwargs: Any
     ) -> Optional[Any]:
         """Run a command **always**.
 
@@ -305,6 +317,8 @@ class Session:
         :param env: A dictionary of environment variables to expose to the
             command. By default, all environment variables are passed.
         :type env: dict or None
+        :param cwd: A :ref:`path-like` object to run the command from.
+        :type cwd: str, pathlib.Path or None
         :param bool silent: Silence command output, unless the command fails.
             ``False`` by default.
         :param success_codes: A list of return codes that are considered
@@ -330,7 +344,11 @@ class Session:
         return self._run(*args, env=env, **kwargs)
 
     def _run(
-        self, *args: str, env: Optional[Mapping[str, str]] = None, **kwargs: Any
+        self,
+        *args: str,
+        env: Optional[Mapping[str, str]] = None,
+        cwd: Optional[Union[str, bytes, os.PathLike[str], os.PathLike[bytes]]] = None,
+        **kwargs: Any
     ) -> Any:
         """Like run(), except that it runs even if --install-only is provided."""
         # Legacy support - run a function given.
@@ -357,7 +375,7 @@ class Session:
             kwargs["external"] = True
 
         # Run a shell command.
-        return nox.command.run(args, env=env, paths=self.bin_paths, **kwargs)
+        return nox.command.run(args, env=env, cwd=cwd, paths=self.bin_paths, **kwargs)
 
     def conda_install(
         self, *args: str, auto_offline: bool = True, **kwargs: Any

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -140,6 +140,33 @@ def test_run_cwd_getcwd():
     assert temp_cwd in result
 
 
+def test_run_cwd_scoped_onsuccess():
+    original_cwd = os.getcwd()
+
+    exit_code = 0
+    args = [PYTHON, "-c", f"import sys;sys.exit({exit_code})"]
+
+    with TemporaryDirectory() as temp_cwd:
+        _ = nox.command.run(args, silent=True, cwd=temp_cwd)
+
+    assert original_cwd == os.getcwd()
+
+
+def test_run_cwd_scoped_onfailure():
+    original_cwd = os.getcwd()
+
+    exit_code = 1
+    args = [PYTHON, "-c", f"import sys;sys.exit({exit_code})"]
+
+    with TemporaryDirectory() as temp_cwd:
+        try:
+            _ = nox.command.run(args, silent=True, cwd=temp_cwd)
+        except nox.command.CommandFailed:
+            pass
+
+    assert original_cwd == os.getcwd()
+
+
 def test_run_not_found():
     with pytest.raises(nox.command.CommandFailed):
         nox.command.run(["nonexistentcmd"])

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -20,8 +20,8 @@ import signal
 import subprocess
 import sys
 import time
-from textwrap import dedent
 from tempfile import TemporaryDirectory
+from textwrap import dedent
 from unittest import mock
 
 import pytest
@@ -134,7 +134,7 @@ def test_run_env_systemroot():
 def test_run_cwd_getcwd():
     with TemporaryDirectory() as temp_cwd:
         result = nox.command.run(
-            [PYTHON, "-c", 'import os;print(os.getcwd())'], silent=True, cwd=temp_cwd
+            [PYTHON, "-c", "import os;print(os.getcwd())"], silent=True, cwd=temp_cwd
         )
 
     assert temp_cwd in result

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -21,6 +21,7 @@ import subprocess
 import sys
 import time
 from textwrap import dedent
+from tempfile import TemporaryDirectory
 from unittest import mock
 
 import pytest
@@ -128,6 +129,15 @@ def test_run_env_systemroot():
     )
 
     assert systemroot in result
+
+
+def test_run_cwd_getcwd():
+    with TemporaryDirectory() as temp_cwd:
+        result = nox.command.run(
+            [PYTHON, "-c", 'import os;print(os.getcwd())'], silent=True, cwd=temp_cwd
+        )
+
+    assert temp_cwd in result
 
 
 def test_run_not_found():


### PR DESCRIPTION
Closes #512

Adds a `cwd` keyword argument for running commands. Uses directly the underlying `subprocess.Popen` API.
