### PR TITLE
Use shutil.rmtree over shelling out to rm -rf in noxfile

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -16,6 +16,7 @@
 import functools
 import os
 import platform
+import shutil
 import sys
 
 import nox
@@ -118,7 +119,7 @@ def docs(session):
     doctrees, html = map(
         functools.partial(os.path.join, output_dir), ["doctrees", "html"]
     )
-    session.run("rm", "-rf", output_dir, external=True)
+    shutil.rmtree(output_dir, ignore_errors=True)
     session.install("-r", "requirements-test.txt")
     session.install(".")
     session.cd("docs")


### PR DESCRIPTION
I was looking through the older issues to try and find the low hanging fruit to close off and found #298.

This PR addresses point 1:

> 1. Change `rm -rf` to [`shutil.rmtree`](https://docs.python.org/3/library/shutil.html#shutil.rmtree).

I did some digging around points 2 and 3, it would seem that point 2 at least has been resolved anyway (see [here](https://github.com/tornadoweb/tornado/issues/2608#issuecomment-736185273)).

> 2. Change the Python version to 3.7 because [sphinx-autobuild](https://github.com/GaretJax/sphinx-autobuild/issues/77), which relies on [tornado](https://github.com/tornadoweb/tornado/issues/2608), no longer works on Windows on 3.8.

Point 3 I'm not too sure and I don't have access to a Windows machine to easily test but since we build the official project docs in an ubuntu image on CI I don't see a major issue here?
> 3. Sphinx fails to follow the reference to changelog and contributing.

Unrelated, but I also noticed that on my machine (macos, python 3.10) running bare `nox` results in ugly looking failures because it tries to run `conda-tests` and I don't have conda installed. A simple switch should fix this:

```python
nox.options.sessions = ["tests", "cover", "blacken", "lint", "docs"]
if shutil.which("conda"):
    nox.options.sessions.append("conda_tests")
```

I'll raise that in a separate issue/PR though to keep things clean 👍🏻 