### PR TITLE
Skip `conda_tests` session by default if user does not have conda

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -23,6 +23,11 @@ import nox
 
 ON_WINDOWS_CI = "CI" in os.environ and platform.system() == "Windows"
 
+# Skip 'conda_tests' if user doesn't have conda installed
+nox.options.sessions = ["tests", "cover", "blacken", "lint", "docs"]
+if shutil.which("conda"):
+    nox.options.sessions.append("conda_tests")
+
 
 def is_python_version(session, version):
     if not version.startswith(session.python):

--- a/tests/test_virtualenv.py
+++ b/tests/test_virtualenv.py
@@ -233,6 +233,7 @@ def test_condaenv_bin_windows(make_conda):
     assert [dir_.strpath, dir_.join("Scripts").strpath] == venv.bin_paths
 
 
+@pytest.mark.skipif(not HAS_CONDA, reason="Missing conda command.")
 def test_condaenv_(make_conda):
     venv, dir_ = make_conda()
     assert not venv.is_offline()


### PR DESCRIPTION
Fixes #520

Adds a simple session filter at the top of our `noxfile.py` that runs all sessions (other than `conda_tests`) by default, only adding `conda_tests` if the user has conda installed.

```python
# Skip 'conda_tests' if user doesn't have conda installed
nox.options.sessions = ["tests", "cover", "blacken", "lint", "docs"]
if shutil.which("conda"):
    nox.options.sessions.append("conda_tests")
```

I also spotted a stray conda-dependent test without a `pytest.mark.skipif(not HAS_CONDA)` guard on it so I quickly added that too:

```python
@pytest.mark.skipif(not HAS_CONDA, reason="Missing conda command.")
def test_condaenv_(make_conda):
    venv, dir_ = make_conda()
    assert not venv.is_offline()
```