### PR TITLE
feat: support FORCE_COLOR

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -329,7 +329,8 @@ Controlling color output
 By default, Nox will output colorful logs if you're using in an interactive
 terminal. However, if you are redirecting ``stderr`` to a file or otherwise
 not using an interactive terminal, or the environment variable ``NO_COLOR`` is
-set, nox will output in plaintext.
+set, nox will output in plaintext. If this is not set, and ``FORCE_COLOR`` is
+present, color will be forced.
 
 You can manually control Nox's output using the ``--nocolor`` and ``--forcecolor`` flags.
 

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -463,7 +463,7 @@ options.add_options(
         "--forcecolor",
         "--force-color",
         group=options.groups["reporting"],
-        default=False,
+        default=lambda: "FORCE_COLOR" in os.environ,
         action="store_true",
         help="Force color output, even if stdout is not an interactive terminal.",
     ),


### PR DESCRIPTION
Closes #502.

This is going with `FORCE_COLOR`, following PyPA/build, pytest, & tox. Could be changed.
