### PR TITLE
chore: bump linting versions to latest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,3 +76,6 @@ target/
 
 # PyCharm
 .idea/
+
+# Standard venv location
+.venv

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -4,7 +4,7 @@ build:
   image: latest
 
 python:
-  version: 3.8
+  version: 3.9
   pip_install: true
 
 requirements_file: requirements-test.txt

--- a/nox/_decorators.py
+++ b/nox/_decorators.py
@@ -16,7 +16,7 @@ import copy
 import functools
 import inspect
 import types
-from typing import Any, Callable, Dict, Iterable, List, Optional, cast
+from typing import Any, Callable, Dict, Iterable, List, Optional
 
 from . import _typing
 
@@ -29,7 +29,7 @@ class FunctionDecorator:
         cls, func: Callable[..., Any], *args: Any, **kwargs: Any
     ) -> "FunctionDecorator":
         obj = super().__new__(cls)
-        return cast("FunctionDecorator", functools.wraps(func)(obj))
+        return functools.wraps(func)(obj)
 
 
 def _copy_func(src: Callable, name: Optional[str] = None) -> Callable:

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -155,7 +155,7 @@ def parametrize_decorator(
 
 
 def update_param_specs(
-    param_specs: Iterable[Param], new_specs: List[Param]
+    param_specs: Optional[Iterable[Param]], new_specs: List[Param]
 ) -> List[Param]:
     """Produces all combinations of the given sets of specs."""
     if not param_specs:

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -63,8 +63,7 @@ def _load_and_exec_nox_module(global_config: Namespace) -> types.ModuleType:
     if not loader:  # pragma: no cover
         raise IOError(f"Could not get module loader for {global_config.noxfile}")
     # See https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
-    # unsure why mypy doesn't like this
-    loader.exec_module(module)  # type: ignore
+    loader.exec_module(module)
     return module
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -90,34 +90,36 @@ def cover(session):
     session.run("coverage", "erase")
 
 
-@nox.session(python="3.8")
+black_pins = ["black==21.12b0", "isort==5.10.1"]
+
+
+@nox.session(python="3.9")
 def blacken(session):
     """Run black code formatter."""
-    session.install("black==21.5b2", "isort==5.8.0")
+    session.install(*black_pins)
     files = ["nox", "tests", "noxfile.py", "docs/conf.py"]
     session.run("black", *files)
     session.run("isort", *files)
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def lint(session):
     session.install(
-        "flake8==3.9.2",
-        "black==21.6b0",
-        "isort==5.8.0",
-        "mypy==0.902",
+        *black_pins,
+        "flake8==4.0.1",
+        "mypy==0.930",
         "types-jinja2",
         "packaging",
         "importlib_metadata",
     )
-    session.run("mypy")
+    session.run("mypy", "--show-error-codes")
     files = ["nox", "tests", "noxfile.py", "docs/conf.py"]
     session.run("black", "--check", *files)
     session.run("isort", "--check", *files)
     session.run("flake8", *files)
 
 
-@nox.session(python="3.8")
+@nox.session(python="3.9")
 def docs(session):
     """Build the documentation."""
     output_dir = os.path.join(session.create_tmp(), "output")


### PR DESCRIPTION
I've bumped the linting versions to latests, cleaned up the mypy updates, and bumped from Python 3.8 to Python 3.9.

Are you interested in moving to pre-commit + pre-commit.ci, perhaps? That would automate this process of bumping pins and would also help new contributors by automatically running the auto-fixes ("blacken") on PRs if you want it to. I'd apply the method described in https://scikit-hep.org/developer/style and used in pybind11, cibuildwheel, etc.
