### PR TITLE
Unpin docs session and add --error-on-missing-interpreter to CI sessions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check .
       - name: Run tests on ${{ matrix.os }}
-        run: nox --non-interactive --session "tests-${{ matrix.python-version }}" -- --full-trace
+        run: nox --non-interactive --error-on-missing-interpreter --session "tests-${{ matrix.python-version }}" -- --full-trace
   lint:
     runs-on: ubuntu-20.04
     steps:
@@ -35,7 +35,7 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check .
       - name: Lint
-        run: nox --non-interactive --session "lint"
+        run: nox --non-interactive --error-on-missing-interpreter --session "lint"
   docs:
     runs-on: ubuntu-20.04
     steps:
@@ -48,7 +48,7 @@ jobs:
         run: |
           python -m pip install --disable-pip-version-check .
       - name: Docs
-        run: nox --non-interactive --session "docs"
+        run: nox --non-interactive --error-on-missing-interpreter --session "docs"
   deploy:
     needs: build
     runs-on: ubuntu-20.04

--- a/noxfile.py
+++ b/noxfile.py
@@ -119,7 +119,7 @@ def lint(session):
     session.run("flake8", *files)
 
 
-@nox.session(python="3.9")
+@nox.session
 def docs(session):
     """Build the documentation."""
     output_dir = os.path.join(session.create_tmp(), "output")


### PR DESCRIPTION
Closes #531 

I've unpinned the `docs` session, leaving `lint` and `blacken` pinned to python 3.9.

I've also added the `--error-on-missing-interpreter` flag to all CI invocations of Nox, to catch any future silent "passes"