### PR TITLE
Document how `session.run` fails, and how to handle failures 

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -267,12 +267,10 @@ class Session:
         ``try...finally`` block for cleanup runs, that will run even if the other runs fail::
 
            try:
-              session.run("git", "stash", "-k", "-u")
-              session.run("isort", "--check-only", "--profile=black", ".")
-              session.run("black", "--check", ".")
-              session.run("mypy", "--strict", ".")
+               session.run("coverage", "run", "-m", "pytest")
            finally:
-              session.run("git", "stash", "pop")
+               # Display coverage report even when tests fail.
+               session.run("coverage", "report")
 
         :param env: A dictionary of environment variables to expose to the
             command. By default, all environment variables are passed.

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -262,6 +262,18 @@ class Session:
 
             session.run('cmd', '/c', 'del', 'docs/modules.rst')
 
+        If ``session.run`` fails, it will stop the session and will not run the next steps.
+        Basically, this will raise a Python exception. Taking this in count, you can use a
+        ``try...finally`` block for cleanup runs, that will run even if the other runs fail::
+
+           try:
+              session.run("git", "stash", "-k", "-u")
+              session.run("isort", "--check-only", "--profile=black", ".")
+              session.run("black", "--check", ".")
+              session.run("mypy", "--strict", ".")
+           finally:
+              session.run("git", "stash", "pop")
+
         :param env: A dictionary of environment variables to expose to the
             command. By default, all environment variables are passed.
         :type env: dict or None


### PR DESCRIPTION
Closes #517.

This PR added a docstring to explain how `session.run` fails and stop the session. Also, I documented how to handle these failures, like described in #517.