### PR TITLE
Update dependencies for conda_tests

### DIFF
--- a/requirements-conda-test.txt
+++ b/requirements-conda-test.txt
@@ -1,5 +1,5 @@
 argcomplete >=1.9.4,<2.0
-colorlog >=2.6.1,<4.0.0
+colorlog >=2.6.1,<7.0.0
 py >=1.4.0,<2.0.0
 virtualenv >=14.0.0
 jinja2


### PR DESCRIPTION
Max version of colorlog in `requirements-conda-test.txt` does not support Python > 3.7 making `nox -s conda_tests` fail. The conda_tests session in not run in CI so this is only an issue when running locally.