### PR TITLE
Fix project's noxfile sessions definition

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -24,7 +24,7 @@ import nox
 ON_WINDOWS_CI = "CI" in os.environ and platform.system() == "Windows"
 
 # Skip 'conda_tests' if user doesn't have conda installed
-nox.options.sessions = ["tests", "cover", "blacken", "lint", "docs"]
+nox.options.sessions = ["tests", "cover", "lint", "docs"]
 if shutil.which("conda"):
     nox.options.sessions.append("conda_tests")
 
@@ -92,6 +92,7 @@ def cover(session):
 
 @nox.session(python="3.9")
 def lint(session):
+    """Run pre-commit linting."""
     session.install("pre-commit")
     session.run(
         "pre-commit", "run", "--all-files", "--show-diff-on-failure", *session.posargs


### PR DESCRIPTION
Fixes an error in the project's own `noxfile.py` where the `blacken` session was explicitly
listed in `nox.options.sessions` but no longer exists due to being replaced by the pre-commit checks introduced in #530.

Without this fix, just running `nox` will result in the following:

<img width="334" alt="image" src="https://user-images.githubusercontent.com/62767721/147470487-79a06265-93ae-42c4-a482-b30596dcae10.png">
