### PR TITLE
ci: Enable color output from Nox, pytest, and pre-commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 on: [push, pull_request]
+env:
+  FORCE_COLOR: "1"
+  PRE_COMMIT_COLOR: "always"
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -602,6 +602,7 @@ def test_main_noxfile_options_with_sessions_override(
 
 @pytest.mark.parametrize(("isatty_value", "expected"), [(True, True), (False, False)])
 def test_main_color_from_isatty(monkeypatch, isatty_value, expected):
+    monkeypatch.delenv("FORCE_COLOR")
     monkeypatch.setattr(sys, "argv", [sys.executable])
     with mock.patch("nox.workflow.execute") as execute:
         execute.return_value = 0
@@ -626,6 +627,7 @@ def test_main_color_from_isatty(monkeypatch, isatty_value, expected):
     ],
 )
 def test_main_color_options(monkeypatch, color_opt, expected):
+    monkeypatch.delenv("FORCE_COLOR")
     monkeypatch.setattr(sys, "argv", [sys.executable, color_opt])
     with mock.patch("nox.workflow.execute") as execute:
         execute.return_value = 0


### PR DESCRIPTION
This enables color output on GitHub Actions for Nox itself, as well as pytest and pre-commit, using workflow-wide environment variables. Nox and pytest support `FORCE_COLOR`, while pre-commit supports `PRE_COMMIT_COLOR`.