### PR TITLE
Pin virtualenv version in lint session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -93,7 +93,9 @@ def cover(session):
 @nox.session(python="3.9")
 def lint(session):
     """Run pre-commit linting."""
-    session.install("pre-commit")
+    # Pin virtualenv for pre-commit run
+    # See https://github.com/theacodes/nox/issues/545
+    session.install("virtualenv==20.10.0", "pre-commit")
     session.run(
         "pre-commit", "run", "--all-files", "--show-diff-on-failure", *session.posargs
     )


### PR DESCRIPTION
Closes #545 

virtualenv today released [20.11.0](https://github.com/pypa/virtualenv/blob/main/docs/changelog.rst#features---20110) which internally bumps the embedded version of setuptools from 58.3.0 to 59.4.0, which must have contained some breaking change for pre-commit as it depends on [virtualenv>=20.0.8](https://github.com/pre-commit/pre-commit/blob/16f68254a84df8d69431bab2ba410770746b95bd/setup.cfg#L32) so it would have pulled this latest version in

Pinning virtualenv to 20.10.0 inside the lint session has fixed the issue

