### PR TITLE
Fix local test failure to do with FORCE_COLOR

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -602,7 +602,8 @@ def test_main_noxfile_options_with_sessions_override(
 
 @pytest.mark.parametrize(("isatty_value", "expected"), [(True, True), (False, False)])
 def test_main_color_from_isatty(monkeypatch, isatty_value, expected):
-    monkeypatch.delenv("FORCE_COLOR")
+    if os.getenv("FORCE_COLOR"):
+        monkeypatch.delenv("FORCE_COLOR")
     monkeypatch.setattr(sys, "argv", [sys.executable])
     with mock.patch("nox.workflow.execute") as execute:
         execute.return_value = 0
@@ -627,7 +628,8 @@ def test_main_color_from_isatty(monkeypatch, isatty_value, expected):
     ],
 )
 def test_main_color_options(monkeypatch, color_opt, expected):
-    monkeypatch.delenv("FORCE_COLOR")
+    if os.getenv("FORCE_COLOR"):
+        monkeypatch.delenv("FORCE_COLOR")
     monkeypatch.setattr(sys, "argv", [sys.executable, color_opt])
     with mock.patch("nox.workflow.execute") as execute:
         execute.return_value = 0

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -602,8 +602,7 @@ def test_main_noxfile_options_with_sessions_override(
 
 @pytest.mark.parametrize(("isatty_value", "expected"), [(True, True), (False, False)])
 def test_main_color_from_isatty(monkeypatch, isatty_value, expected):
-    if os.getenv("FORCE_COLOR"):
-        monkeypatch.delenv("FORCE_COLOR")
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
     monkeypatch.setattr(sys, "argv", [sys.executable])
     with mock.patch("nox.workflow.execute") as execute:
         execute.return_value = 0
@@ -628,8 +627,7 @@ def test_main_color_from_isatty(monkeypatch, isatty_value, expected):
     ],
 )
 def test_main_color_options(monkeypatch, color_opt, expected):
-    if os.getenv("FORCE_COLOR"):
-        monkeypatch.delenv("FORCE_COLOR")
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
     monkeypatch.setattr(sys, "argv", [sys.executable, color_opt])
     with mock.patch("nox.workflow.execute") as execute:
         execute.return_value = 0


### PR DESCRIPTION
I noticed that some tests are now failing on my machine with a `KeyError` because the `FORCE_COLOR` env variable is not set (which is why they don't fail on CI) and we're trying to monkeypatch the value.

<img width="838" alt="image" src="https://user-images.githubusercontent.com/62767721/147575502-c51ec873-7e4f-4d37-8c3c-3fa5913f076e.png">


This PR adds a quick check to see if it's set first before monkeypatching the value for tests 👍🏻 