### PR TITLE
Fix virtualenv setuptools

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ on: [push, pull_request]
 env:
   FORCE_COLOR: "1"
   PRE_COMMIT_COLOR: "always"
+  SETUPTOOLS_USE_DISTUTIL: "stdlib"
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,9 @@ on: [push, pull_request]
 env:
   FORCE_COLOR: "1"
   PRE_COMMIT_COLOR: "always"
-  SETUPTOOLS_USE_DISTUTILS: "stdlib" # See https://github.com/theacodes/nox/issues/545
+  # See https://github.com/theacodes/nox/issues/545
+  # and https://github.com/pre-commit/pre-commit/issues/2178#issuecomment-1002163763
+  SETUPTOOLS_USE_DISTUTILS: "stdlib"
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 env:
   FORCE_COLOR: "1"
   PRE_COMMIT_COLOR: "always"
-  SETUPTOOLS_USE_DISTUTIL: "stdlib"
+  SETUPTOOLS_USE_DISTUTILS: "stdlib" # See https://github.com/theacodes/nox/issues/545
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/noxfile.py
+++ b/noxfile.py
@@ -91,11 +91,17 @@ def cover(session):
 
 
 @nox.session(python="3.9")
-def lint(session):
+def lint(session: nox.Session):
     """Run pre-commit linting."""
     session.install("pre-commit")
+    # See https://github.com/theacodes/nox/issues/545
+    # and https://github.com/pre-commit/pre-commit/issues/2178#issuecomment-1002163763
     session.run(
-        "pre-commit", "run", "--all-files", "--show-diff-on-failure", *session.posargs
+        "pre-commit",
+        "run",
+        "--all-files",
+        "--show-diff-on-failure",
+        env={"SETUPTOOLS_USE_DISTUTILS": "stdlib"},
     )
 
 

--- a/noxfile.py
+++ b/noxfile.py
@@ -93,9 +93,7 @@ def cover(session):
 @nox.session(python="3.9")
 def lint(session):
     """Run pre-commit linting."""
-    # Pin virtualenv for pre-commit run
-    # See https://github.com/theacodes/nox/issues/545
-    session.install("virtualenv==20.10.0", "pre-commit")
+    session.install("pre-commit")
     session.run(
         "pre-commit", "run", "--all-files", "--show-diff-on-failure", *session.posargs
     )

--- a/noxfile.py
+++ b/noxfile.py
@@ -91,7 +91,7 @@ def cover(session):
 
 
 @nox.session(python="3.9")
-def lint(session: nox.Session):
+def lint(session):
     """Run pre-commit linting."""
     session.install("pre-commit")
     # See https://github.com/theacodes/nox/issues/545
@@ -102,6 +102,7 @@ def lint(session: nox.Session):
         "--all-files",
         "--show-diff-on-failure",
         env={"SETUPTOOLS_USE_DISTUTILS": "stdlib"},
+        *session.posargs,
     )
 
 


### PR DESCRIPTION
Related to discussion in #547.

Related explanation: https://github.com/pre-commit/pre-commit/issues/2178#issuecomment-1002163763

Turns out a better solution to pinning virtualenv is enforcing the stdlib setuptools in CI through an environment variable, which this PR implements