### PR TITLE
Remove MANIFEST.in in favour of setup.cfg package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,0 @@
-recursive-include nox *.jinja2
-include nox/py.typed

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ tox_to_nox =
     tox
 
 [options.package_data]
-nox = py.typed
+nox = py.typed, *.jinja2
 
 [flake8]
 extend-ignore = E501, W503, E203


### PR DESCRIPTION
This PR removes `MANIFEST.in` in favour of specifying required package data in `setup.cfg`

I've validated that the produced tarballs are equivalent by running `pyproject-build` then extracting the resulting tarball to verify it's contents:

### Before (with `MANIFEST.in`)

<img width="447" alt="before" src="https://user-images.githubusercontent.com/62767721/147589639-e2416ea9-5a8b-4214-a674-489f2157fdc4.png">


### After (with `setup.cfg` package_data)

<img width="481" alt="after" src="https://user-images.githubusercontent.com/62767721/147589678-9132cd19-bdd9-4a4c-8d97-84c6fa15af90.png">

The only entries in `MANIFEST.in` were `py.typed` and anything with a `.jinja2` extension which you can see in the images are still present 🙂