### PR TITLE
style: check manifest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -87,3 +87,9 @@ repos:
   - id: rst-backticks
   - id: rst-directive-colons
   - id: rst-inline-touching-normal
+
+- repo: https://github.com/mgedmin/check-manifest
+  rev: "0.47"
+  hooks:
+  - id: check-manifest
+    stages: [manual]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 recursive-include nox *.jinja2
 include nox/py.typed
+recursive-include tests *.py

--- a/noxfile.py
+++ b/noxfile.py
@@ -101,6 +101,7 @@ def lint(session):
         "run",
         "--all-files",
         "--show-diff-on-failure",
+        "--hook-stage=manual",
         env={"SETUPTOOLS_USE_DISTUTILS": "stdlib"},
         *session.posargs,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,6 @@ ignore_missing_imports = true
 [tool.check-manifest]
 ignore = [
     "docs/**",
-    "tests/**",  # ?
     "noxfile.py",
     "requirements-conda-test.txt",
     "requirements-test.txt",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,14 @@ strict_equality = true
 [[tool.mypy.overrides]]
 module = [ "argcomplete", "colorlog.*", "py", "tox.*" ]
 ignore_missing_imports = true
+
+[tool.check-manifest]
+ignore = [
+    "docs/**",
+    "tests/**",  # ?
+    "noxfile.py",
+    "requirements-conda-test.txt",
+    "requirements-test.txt",
+    "*.md",
+    ".*",
+]


### PR DESCRIPTION
Adds a manual check for the manifest (runs when running `nox -s lint`, but won't auto-run on `pre-commit install` or on `pre-commit.ci`, because it's kind of slow).

This adds the missing tests folder to the SDist. Some users (especially packagers like conda-forge and linux distros) like having it in the SDist.

See #550.