### PR TITLE
fix: support changing directory with TMPDIR

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -202,7 +202,7 @@ class Session:
         """Create, and return, a temporary directory."""
         tmpdir = os.path.join(self._runner.envdir, "tmp")
         os.makedirs(tmpdir, exist_ok=True)
-        self.env["TMPDIR"] = tmpdir
+        self.env["TMPDIR"] = os.path.abspath(tmpdir)
         return tmpdir
 
     @property

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -84,7 +84,7 @@ class TestSession:
         with tempfile.TemporaryDirectory() as root:
             runner.global_config.envdir = root
             tmpdir = session.create_tmp()
-            assert session.env["TMPDIR"] == tmpdir
+            assert session.env["TMPDIR"] == os.path.abspath(tmpdir)
             assert tmpdir.startswith(root)
 
     def test_create_tmp_twice(self):
@@ -94,7 +94,7 @@ class TestSession:
             runner.venv.bin = bin
             session.create_tmp()
             tmpdir = session.create_tmp()
-            assert session.env["TMPDIR"] == tmpdir
+            assert session.env["TMPDIR"] == os.path.abspath(tmpdir)
             assert tmpdir.startswith(root)
 
     def test_properties(self):


### PR DESCRIPTION
This is a minimal fix to the bug, though maybe `create_tmp` should also be absolute? That's less important, because someone could construct the correct path, while TMPDIR simply breaks.

Closes #555
