### PR TITLE
docs: use myst-parser for md

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,7 +39,7 @@ sys.path.insert(0, os.path.abspath("."))
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
-    "recommonmark",
+    "myst_parser",
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,7 +1,7 @@
 flask
+myst-parser
 pytest
 pytest-cov
-recommonmark
 sphinx>=3.0
 sphinx-autobuild
 witchhazel


### PR DESCRIPTION
Closes #559 again.

See https://github.com/readthedocs/recommonmark/issues/221 - recommonmark has been sun-setted, myst-parser is the replacement.