### PR TITLE
feat: allow configurable child shutdown timeouts

### DIFF
--- a/nox/_options.py
+++ b/nox/_options.py
@@ -139,7 +139,7 @@ def _envdir_merge_func(
 
 def _child_shutdown_timeout_merge_func(
     command_args: argparse.Namespace, noxfile_args: argparse.Namespace
-) -> str:
+) -> Union[float, None]:
     """Merge child_shutdown_timeout from command args and nox file.
 
     Args:

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -139,26 +139,6 @@ def _envdir_merge_func(
     return command_args.envdir or noxfile_args.envdir or ".nox"
 
 
-def _child_shutdown_timeout_merge_func(
-    command_args: argparse.Namespace, noxfile_args: argparse.Namespace
-) -> float | None:
-    """Merge child_shutdown_timeout from command args and nox file.
-
-    Args:
-        command_args (_option_set.Namespace): The options specified on the
-            command-line.
-        noxfile_Args (_option_set.Namespace): The options specified in the
-            Noxfile.
-    """
-    try:
-        return float(command_args.child_shutdown_timeout)
-    except (ValueError, TypeError):
-        try:
-            return float(noxfile_args.child_shutdown_timeout)
-        except (ValueError, TypeError):
-            return None
-
-
 def _sessions_default() -> list[str] | None:
     """Looks at the NOXSESSION env var to set the default value for sessions."""
     nox_env = os.environ.get("NOXSESSION")
@@ -455,18 +435,6 @@ options.add_options(
             "Skip invocations of session methods for installing packages"
             " (session.install, session.conda_install, session.run_always)"
             " when a virtualenv is being reused."
-        ),
-    ),
-    _option_set.Option(
-        "child_shutdown_timeout",
-        "--child-shutdown-timeout",
-        noxfile=True,
-        merge_func=_child_shutdown_timeout_merge_func,
-        type=float,
-        group=options.groups["execution"],
-        help=(
-            "The number of seconds to wait for children to shut down cleanly after "
-            "receiving a SIGTERM signal before sending them a SIGKILL signal."
         ),
     ),
     _option_set.Option(

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -137,6 +137,26 @@ def _envdir_merge_func(
     return command_args.envdir or noxfile_args.envdir or ".nox"
 
 
+def _child_shutdown_timeout_merge_func(
+    command_args: argparse.Namespace, noxfile_args: argparse.Namespace
+) -> str:
+    """Merge child_shutdown_timeout from command args and nox file.
+
+    Args:
+        command_args (_option_set.Namespace): The options specified on the
+            command-line.
+        noxfile_Args (_option_set.Namespace): The options specified in the
+            Noxfile.
+    """
+    try:
+        return float(command_args.child_shutdown_timeout)
+    except (ValueError, TypeError):
+        try:
+            return float(noxfile_args.child_shutdown_timeout)
+        except (ValueError, TypeError):
+            return None
+
+
 def _sessions_default() -> Optional[List[str]]:
     """Looks at the NOXSESSION env var to set the default value for sessions."""
     nox_env = os.environ.get("NOXSESSION")
@@ -433,6 +453,18 @@ options.add_options(
             "Skip invocations of session methods for installing packages"
             " (session.install, session.conda_install, session.run_always)"
             " when a virtualenv is being reused."
+        ),
+    ),
+    _option_set.Option(
+        "child_shutdown_timeout",
+        "--child-shutdown-timeout",
+        noxfile=True,
+        merge_func=_child_shutdown_timeout_merge_func,
+        type=float,
+        group=options.groups["execution"],
+        help=(
+            "The number of seconds to wait for children to shut down cleanly after "
+            "receiving a SIGTERM signal before sending them a SIGKILL signal."
         ),
     ),
     _option_set.Option(

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -23,8 +23,8 @@ from typing import IO, Mapping, Sequence
 
 def shutdown_process(
     proc: subprocess.Popen,
-    interrupt_timeout: float,
-    terminate_timeout: float,
+    interrupt_timeout: float | None,
+    terminate_timeout: float | None,
 ) -> tuple[bytes, bytes]:
     """Gracefully shutdown a child process."""
     with contextlib.suppress(subprocess.TimeoutExpired):
@@ -63,8 +63,8 @@ def popen(
     silent: bool = False,
     stdout: int | IO | None = None,
     stderr: int | IO = subprocess.STDOUT,
-    interrupt_timeout: float = 0.3,
-    terminate_timeout: float = 0.2,
+    interrupt_timeout: float | None = 0.3,
+    terminate_timeout: float | None = 0.2,
 ) -> tuple[int, str]:
     if silent and stdout is not None:
         raise ValueError(

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -19,11 +19,13 @@ import sys
 from typing import IO, Mapping, Optional, Sequence, Tuple, Union
 
 
-def shutdown_process(proc: subprocess.Popen) -> Tuple[bytes, bytes]:
+def shutdown_process(
+    proc: subprocess.Popen, child_timeout: Optional[float]
+) -> Tuple[bytes, bytes]:
     """Gracefully shutdown a child process."""
 
     with contextlib.suppress(subprocess.TimeoutExpired):
-        return proc.communicate(timeout=0.3)
+        return proc.communicate(timeout=child_timeout or 0.3)
 
     proc.terminate()
 
@@ -58,6 +60,7 @@ def popen(
     silent: bool = False,
     stdout: Optional[Union[int, IO]] = None,
     stderr: Union[int, IO] = subprocess.STDOUT,
+    child_shutdown_timeout: Optional[float] = None,
 ) -> Tuple[int, str]:
     if silent and stdout is not None:
         raise ValueError(
@@ -74,7 +77,7 @@ def popen(
         sys.stdout.flush()
 
     except KeyboardInterrupt:
-        out, err = shutdown_process(proc)
+        out, err = shutdown_process(proc, child_shutdown_timeout)
         if proc.returncode != 0:
             raise
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -274,7 +274,7 @@ class Session:
         complete before being terminated. For example, if you wanted to allow ``pytest``
         extra time to clean up large projects in the case that nox receives an
         interrupt signal from your build system and needs to terminate its child
-        processes.
+        processes::
 
             session.run(
                 'pytest', '-k', 'long_cleanup',

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -271,9 +271,10 @@ class Session:
                 env={'SOME_ENV': 'Hello'})
 
         You can extend the shutdown timeout to allow long-running cleanup tasks to
-        complete before being terminated, for example, to allow pytest to clean up
-        large projects in the case that nox receives an interrupt signal from your
-        build system and needs to terminate its child processes.
+        complete before being terminated. For example, if you wanted to allow ``pytest``
+        extra time to clean up large projects in the case that nox receives an
+        interrupt signal from your build system and needs to terminate its child
+        processes.
 
             session.run(
                 'pytest', '-k', 'long_cleanup',

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -397,6 +397,10 @@ class Session:
         if args[0] in self.virtualenv.allowed_globals:
             kwargs["external"] = True
 
+        kwargs.setdefault(
+            "child_shutdown_timeout", self._runner.global_config.child_shutdown_timeout
+        )
+
         # Run a shell command.
         return nox.command.run(args, env=env, paths=self.bin_paths, **kwargs)
 

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -273,7 +273,7 @@ class Session:
         You can extend the shutdown timeout to allow long-running cleanup tasks to
         complete before being terminated, for example, to allow pytest to clean up
         large projects in the case that nox receives an interrupt signal from your
-        build system and needs to terminate its child processes. 
+        build system and needs to terminate its child processes.
 
             session.run(
                 'pytest', '-k', 'long_cleanup',

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -270,6 +270,16 @@ class Session:
                 'bash', '-c', 'echo $SOME_ENV',
                 env={'SOME_ENV': 'Hello'})
 
+        You can extend the shutdown timeout to allow long-running cleanup tasks to
+        complete before being terminated, for example, to allow pytest to clean up
+        large projects in the case that nox receives an interrupt signal from your
+        build system and needs to terminate its child processes. 
+
+            session.run(
+                'pytest', '-k', 'long_cleanup',
+                interrupt_timeout=10.0,
+                terminate_timeout=2.0)
+
         You can also tell nox to treat non-zero exit codes as success using
         ``success_codes``. For example, if you wanted to treat the ``pytest``
         "tests discovered, but none selected" error as success::
@@ -308,6 +318,16 @@ class Session:
             ``--error-on-external-run``. This has no effect for sessions that
             do not have a virtualenv.
         :type external: bool
+        :param interrupt_timeout: The timeout (in seconds) that nox should wait after it
+            and its children receive an interrupt signal before sending a terminate
+            signal to its children. Set to ``None`` to never send a terminate signal.
+            Default: ``0.3``
+        :type interrupt_timeout: float or None
+        :param terminate_timeout: The timeout (in seconds) that nox should wait after it
+            sends a terminate signal to its children before sending a kill signal to
+            them. Set to ``None`` to never send a kill signal.
+            Default: ``0.2``
+        :type terminate_timeout: float or None
         """
         if not args:
             raise ValueError("At least one argument required to run().")
@@ -348,6 +368,16 @@ class Session:
             ``--error-on-external-run``. This has no effect for sessions that
             do not have a virtualenv.
         :type external: bool
+        :param interrupt_timeout: The timeout (in seconds) that nox should wait after it
+            and its children receive an interrupt signal before sending a terminate
+            signal to its children. Set to ``None`` to never send a terminate signal.
+            Default: ``0.3``
+        :type interrupt_timeout: float or None
+        :param terminate_timeout: The timeout (in seconds) that nox should wait after it
+            sends a terminate signal to its children before sending a kill signal to
+            them. Set to ``None`` to never send a kill signal.
+            Default: ``0.2``
+        :type terminate_timeout: float or None
         """
         if (
             self._runner.global_config.no_install

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -387,10 +387,6 @@ class Session:
         if args[0] in self.virtualenv.allowed_globals:
             kwargs["external"] = True
 
-        kwargs.setdefault(
-            "child_shutdown_timeout", self._runner.global_config.child_shutdown_timeout
-        )
-
         # Run a shell command.
         return nox.command.run(args, env=env, paths=self.bin_paths, **kwargs)
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -355,7 +355,8 @@ class TestSession:
             "terminate_timeout_expected",
         ),
         [
-            (None, None, 0.3, 0.2),
+            ("default", "default", 0.3, 0.2),
+            (None, None, None, None),
             (0, 0, 0, 0),
             (1, 2, 1, 2),
         ],
@@ -382,9 +383,9 @@ class TestSession:
             shutdown_process.return_value = ("", "")
 
             timeout_kwargs = {}
-            if interrupt_timeout_setting is not None:
+            if interrupt_timeout_setting != "default":
                 timeout_kwargs["interrupt_timeout"] = interrupt_timeout_setting
-            if terminate_timeout_setting is not None:
+            if terminate_timeout_setting != "default":
                 timeout_kwargs["terminate_timeout"] = terminate_timeout_setting
 
             with pytest.raises(KeyboardInterrupt):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -245,6 +245,7 @@ class TestSession:
             external=mock.ANY,
             paths=mock.ANY,
             silent=mock.ANY,
+            child_shutdown_timeout=None,
         )
 
     def test_run_success(self):
@@ -281,7 +282,11 @@ class TestSession:
             session.run(sys.executable, "--version")
 
         run.assert_called_once_with(
-            (sys.executable, "--version"), external=True, env=mock.ANY, paths=None
+            (sys.executable, "--version"),
+            external=True,
+            env=mock.ANY,
+            paths=None,
+            child_shutdown_timeout=None,
         )
 
     def test_run_external_condaenv(self):
@@ -301,6 +306,7 @@ class TestSession:
             external=True,
             env=mock.ANY,
             paths=["/path/to/env/bin"],
+            child_shutdown_timeout=None,
         )
 
     def test_run_external_with_error_on_external_run(self):

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -247,7 +247,6 @@ class TestSession:
             external=mock.ANY,
             paths=mock.ANY,
             silent=mock.ANY,
-            child_shutdown_timeout=None,
         )
 
     def test_run_success(self):
@@ -288,7 +287,6 @@ class TestSession:
             external=True,
             env=mock.ANY,
             paths=None,
-            child_shutdown_timeout=None,
         )
 
     def test_run_external_condaenv(self):
@@ -308,7 +306,6 @@ class TestSession:
             external=True,
             env=mock.ANY,
             paths=["/path/to/env/bin"],
-            child_shutdown_timeout=None,
         )
 
     def test_run_external_with_error_on_external_run(self):
@@ -349,6 +346,55 @@ class TestSession:
         runner.global_config.install_only = True
 
         assert session.run_always(operator.add, 23, 19) == 42
+
+    @pytest.mark.parametrize(
+        (
+            "interrupt_timeout_setting",
+            "terminate_timeout_setting",
+            "interrupt_timeout_expected",
+            "terminate_timeout_expected",
+        ),
+        [
+            (None, None, 0.3, 0.2),
+            (0, 0, 0, 0),
+            (1, 2, 1, 2),
+        ],
+    )
+    def test_run_shutdown_process_timeouts(
+        self,
+        interrupt_timeout_setting,
+        terminate_timeout_setting,
+        interrupt_timeout_expected,
+        terminate_timeout_expected,
+    ):
+        session, runner = self.make_session_and_runner()
+
+        runner.venv = nox.virtualenv.ProcessEnv()
+
+        subp_popen_instance = mock.Mock()
+        subp_popen_instance.communicate.side_effect = KeyboardInterrupt()
+        with mock.patch(
+            "nox.popen.shutdown_process", autospec=True
+        ) as shutdown_process, mock.patch(
+            "nox.popen.subprocess.Popen",
+            new=mock.Mock(return_value=subp_popen_instance),
+        ):
+            shutdown_process.return_value = ("", "")
+
+            timeout_kwargs = {}
+            if interrupt_timeout_setting is not None:
+                timeout_kwargs["interrupt_timeout"] = interrupt_timeout_setting
+            if terminate_timeout_setting is not None:
+                timeout_kwargs["terminate_timeout"] = terminate_timeout_setting
+
+            with pytest.raises(KeyboardInterrupt):
+                session.run(sys.executable, "--version", **timeout_kwargs)
+
+        shutdown_process.assert_called_once_with(
+            proc=mock.ANY,
+            interrupt_timeout=interrupt_timeout_expected,
+            terminate_timeout=terminate_timeout_expected,
+        )
 
     @pytest.mark.parametrize(
         ("no_install", "reused", "run_called"),


### PR DESCRIPTION
Thank you  for the work done in https://github.com/theacodes/nox/pull/393! It did fix some odd issues but brought to light one more. We have a few tests that spin up docker containers and then clean them up after the pytest session exits but these take upwards of 10-15 seconds to fully clean up. I think that making the timeout configurable may be acceptable although I'm not sure if this is the best approach. Let me know what you think.

The goal of this change is to allow you to set the timeout on the CLI, in the `noxfile.py`, or individually on each `session.run` invocation. If this is acceptable I'll work on updating docs and tests. Thanks!