### PR TITLE
Missing interpreters now error the session on CI by default

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -218,13 +218,15 @@ If the Noxfile sets ``nox.options.stop_on_first_error``, you can override the No
 Failing sessions when the interpreter is missing
 ------------------------------------------------
 
-By default, Nox will skip sessions where the Python interpreter can't be found. If you want Nox to mark these sessions as failed, you can use ``--error-on-missing-interpreters``:
+By default, when not on CI, Nox will skip sessions where the Python interpreter can't be found. If you want Nox to mark these sessions as failed, you can use ``--error-on-missing-interpreters``:
 
 .. code-block:: console
 
     nox --error-on-missing-interpreters
 
 If the Noxfile sets ``nox.options.error_on_missing_interpreters``, you can override the Noxfile setting from the command line by using ``--no-error-on-missing-interpreters``.
+
+If being run on Continuous Integration (CI) systems, Nox will treat missing interpreters as errors by default to avoid sessions silently passing when the requested python interpreter is not installed. Nox does this by looking for an environment variable called ``CI`` which is a convention used by most CI providers.
 
 .. _opt-error-on-external-run:
 

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -157,6 +157,7 @@ def make_flag_pair(
     name: str,
     enable_flags: tuple[str, str] | tuple[str],
     disable_flags: tuple[str],
+    default: bool = False,
     **kwargs: Any,
 ) -> tuple[Option, Option]:
     """Returns two options - one to enable a behavior and another to disable it.
@@ -172,6 +173,7 @@ def make_flag_pair(
         *enable_flags,
         noxfile=True,
         merge_func=functools.partial(flag_pair_merge_func, name, disable_name),
+        default=default,
         **kwargs,
     )
 

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -419,7 +419,7 @@ options.add_options(
         ("--no-error-on-missing-interpreters",),
         group=options.groups["execution"],
         help="Error instead of skipping sessions if an interpreter can not be located.",
-        default=True if "CI" in os.environ else False,
+        default="CI" in os.environ,
     ),
     *_option_set.make_flag_pair(
         "error_on_external_run",

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -419,6 +419,7 @@ options.add_options(
         ("--no-error-on-missing-interpreters",),
         group=options.groups["execution"],
         help="Error instead of skipping sessions if an interpreter can not be located.",
+        default=True if "CI" in os.environ else False,
     ),
     *_option_set.make_flag_pair(
         "error_on_external_run",

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -691,7 +691,7 @@ class SessionRunner:
             return Result(self, Status.SUCCESS)
 
         except nox.virtualenv.InterpreterNotFound as exc:
-            if self.global_config.error_on_missing_interpreters or "CI" in os.environ:
+            if self.global_config.error_on_missing_interpreters:
                 return Result(self, Status.FAILED, reason=str(exc))
             else:
                 logger.warning(

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -688,9 +688,13 @@ class SessionRunner:
             return Result(self, Status.SUCCESS)
 
         except nox.virtualenv.InterpreterNotFound as exc:
-            if self.global_config.error_on_missing_interpreters:
+            if self.global_config.error_on_missing_interpreters or "CI" in os.environ:
                 return Result(self, Status.FAILED, reason=str(exc))
             else:
+                logger.warning(
+                    "Missing interpreters will error by default on CI systems."
+                    " Use `--error-on-missing-interpreters` to emulate this behaviour."
+                )
                 return Result(self, Status.SKIPPED, reason=str(exc))
 
         except _SessionQuit as exc:

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -696,7 +696,6 @@ class SessionRunner:
             else:
                 logger.warning(
                     "Missing interpreters will error by default on CI systems."
-                    " Use `--error-on-missing-interpreters` to emulate this behaviour."
                 )
                 return Result(self, Status.SKIPPED, reason=str(exc))
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -749,7 +749,7 @@ class TestSessionRunner:
                 envdir="envdir",
                 posargs=[],
                 reuse_existing_virtualenvs=False,
-                error_on_missing_interpreters=True if "CI" in os.environ else False,
+                error_on_missing_interpreters="CI" in os.environ,
             ),
             manifest=mock.create_autospec(nox.manifest.Manifest),
         )

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -905,9 +905,12 @@ class TestSessionRunner:
         assert "no parameters" in result.reason
 
     def test_execute_skip_missing_interpreter(self, caplog, monkeypatch):
+        # Important to have this first here as the runner will pick it up
+        # to set default for --error-on-missing-interpreters
+        monkeypatch.delenv("CI", raising=False)
+
         runner = self.make_runner_with_mock_venv()
         runner._create_venv.side_effect = nox.virtualenv.InterpreterNotFound("meep")
-        monkeypatch.delenv("CI", raising=False)
 
         result = runner.execute()
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -749,7 +749,7 @@ class TestSessionRunner:
                 envdir="envdir",
                 posargs=[],
                 reuse_existing_virtualenvs=False,
-                error_on_missing_interpreters=False,
+                error_on_missing_interpreters=True if "CI" in os.environ else False,
             ),
             manifest=mock.create_autospec(nox.manifest.Manifest),
         )
@@ -918,9 +918,9 @@ class TestSessionRunner:
         )
 
     def test_execute_missing_interpreter_on_CI(self, monkeypatch):
+        monkeypatch.setenv("CI", "True")
         runner = self.make_runner_with_mock_venv()
         runner._create_venv.side_effect = nox.virtualenv.InterpreterNotFound("meep")
-        monkeypatch.setenv("CI", "True")
 
         result = runner.execute()
 


### PR DESCRIPTION
Closes #340 

This PR adds a check to determine if nox is running on CI when evaluating sessions with missing interpreters so that such sessions fail by default when being run on CI providers.

This has the desired effect:

**Skipped locally showing CI warning**

<img width="911" alt="image" src="https://user-images.githubusercontent.com/62767721/152945814-5e56ff71-4a52-47f6-9387-866d659915db.png">

**CI=true causes an error**

<img width="518" alt="image" src="https://user-images.githubusercontent.com/62767721/152945916-9da4d627-183a-4d6d-a2c5-9d902aa6ab4d.png">

*Note non-zero exit code*

**`--error-on-missing-interpreters` for reference**

<img width="524" alt="image" src="https://user-images.githubusercontent.com/62767721/152945978-8a887048-7db0-443f-ba59-b97f846d4b65.png">

I have some questions I'd like people's input on:

- Should this be documented or just rely on the warning message?
- The warning message is kinda long, any other suggestions that get the point across? Maybe just say it will fail in CI and leave it there without mentioning `--error-on-missing-interpreters`? Given that it will show any time a session is skipped a long message could get annoying.
- Currently we just check for `CI` existing in `os.environ` should it explicitly check for true?