### PR TITLE
Bump pre-commit linter versions to latest

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,94 +3,96 @@ ci:
   autofix_commit_msg: "style: pre-commit fixes"
 
 repos:
-- repo: https://github.com/psf/black
-  rev: 21.12b0
-  hooks:
-  - id: black
+  - repo: https://github.com/psf/black
+    rev: "22.1.0"
+    hooks:
+      - id: black
+        args:
+          - "--preview"
 
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.0.1
-  hooks:
-  - id: check-added-large-files
-  - id: check-case-conflict
-  - id: check-merge-conflict
-  - id: check-symlinks
-  - id: check-yaml
-  - id: debug-statements
-  - id: end-of-file-fixer
-  - id: mixed-line-ending
-  - id: requirements-txt-fixer
-  - id: trailing-whitespace
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.1.0
+    hooks:
+      - id: check-added-large-files
+      - id: check-case-conflict
+      - id: check-merge-conflict
+      - id: check-symlinks
+      - id: check-yaml
+      - id: debug-statements
+      - id: end-of-file-fixer
+      - id: mixed-line-ending
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
 
-- repo: https://github.com/PyCQA/isort
-  rev: 5.10.1
-  hooks:
-  - id: isort
-    args: ["-a", "from __future__ import annotations"]
+  - repo: https://github.com/PyCQA/isort
+    rev: 5.10.1
+    hooks:
+      - id: isort
+        args: ["-a", "from __future__ import annotations"]
 
-- repo: https://github.com/asottile/pyupgrade
-  rev: v2.29.1
-  hooks:
-  - id: pyupgrade
-    args: [--py37-plus]
+  - repo: https://github.com/asottile/pyupgrade
+    rev: v2.31.0
+    hooks:
+      - id: pyupgrade
+        args: [--py37-plus]
 
-- repo: https://github.com/asottile/setup-cfg-fmt
-  rev: v1.20.0
-  hooks:
-  - id: setup-cfg-fmt
+  - repo: https://github.com/asottile/setup-cfg-fmt
+    rev: v1.20.0
+    hooks:
+      - id: setup-cfg-fmt
 
-- repo: https://github.com/hadialqattan/pycln
-  rev: v1.1.0
-  hooks:
-  - id: pycln
-    args: [--config=pyproject.toml]
+  - repo: https://github.com/hadialqattan/pycln
+    rev: v1.1.0
+    hooks:
+      - id: pycln
+        args: [--config=pyproject.toml]
 
-- repo: https://github.com/asottile/yesqa
-  rev: v1.3.0
-  hooks:
-  - id: yesqa
-    additional_dependencies: &flake8-dependencies
-    - flake8-bugbear
+  - repo: https://github.com/asottile/yesqa
+    rev: v1.3.0
+    hooks:
+      - id: yesqa
+        additional_dependencies: &flake8-dependencies
+          - flake8-bugbear
 
-- repo: https://github.com/pycqa/flake8
-  rev: 4.0.1
-  hooks:
-  - id: flake8
-    exclude: docs/conf.py
-    additional_dependencies: *flake8-dependencies
+  - repo: https://github.com/pycqa/flake8
+    rev: 4.0.1
+    hooks:
+      - id: flake8
+        exclude: docs/conf.py
+        additional_dependencies: *flake8-dependencies
 
-- repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v0.920
-  hooks:
-  - id: mypy
-    files: ^nox/
-    args: [--show-error-codes]
-    additional_dependencies:
-    - types-jinja2
-    - packaging
-    - importlib_metadata
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v0.931
+    hooks:
+      - id: mypy
+        files: ^nox/
+        args: [--show-error-codes]
+        additional_dependencies:
+          - types-jinja2
+          - packaging
+          - importlib_metadata
 
-- repo: https://github.com/codespell-project/codespell
-  rev: v2.1.0
-  hooks:
-  - id: codespell
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
+    hooks:
+      - id: codespell
 
-- repo: https://github.com/pre-commit/pygrep-hooks
-  rev: v1.9.0
-  hooks:
-  - id: python-check-blanket-noqa
-  - id: python-check-blanket-type-ignore
-  - id: python-no-log-warn
-    exclude: ^tests/test_sessions.py$
-  - id: python-no-eval
-    exclude: ^nox/manifest.py$
-  - id: python-use-type-annotations
-  - id: rst-backticks
-  - id: rst-directive-colons
-  - id: rst-inline-touching-normal
+  - repo: https://github.com/pre-commit/pygrep-hooks
+    rev: v1.9.0
+    hooks:
+      - id: python-check-blanket-noqa
+      - id: python-check-blanket-type-ignore
+      - id: python-no-log-warn
+        exclude: ^tests/test_sessions.py$
+      - id: python-no-eval
+        exclude: ^nox/manifest.py$
+      - id: python-use-type-annotations
+      - id: rst-backticks
+      - id: rst-directive-colons
+      - id: rst-inline-touching-normal
 
-- repo: https://github.com/mgedmin/check-manifest
-  rev: "0.47"
-  hooks:
-  - id: check-manifest
-    stages: [manual]
+  - repo: https://github.com/mgedmin/check-manifest
+    rev: "0.47"
+    hooks:
+      - id: check-manifest
+        stages: [manual]

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -48,7 +48,8 @@ options.add_groups(
     _option_set.OptionGroup(
         "environment",
         "Environment options",
-        "These arguments are used to control Nox's creation and usage of virtual environments.",
+        "These arguments are used to control Nox's creation and usage of virtual"
+        " environments.",
     ),
     _option_set.OptionGroup(
         "execution",
@@ -317,8 +318,11 @@ options.add_options(
         group=options.groups["environment"],
         noxfile=True,
         merge_func=_default_venv_backend_merge_func,
-        help="Virtual environment backend to use by default for nox sessions, this is ``'virtualenv'`` by default but "
-        "any of ``('virtualenv', 'conda', 'mamba', 'venv')`` are accepted.",
+        help=(
+            "Virtual environment backend to use by default for nox sessions, this is"
+            " ``'virtualenv'`` by default but any of ``('virtualenv', 'conda', 'mamba',"
+            " 'venv')`` are accepted."
+        ),
         choices=["none", "virtualenv", "conda", "mamba", "venv"],
     ),
     _option_set.Option(
@@ -328,9 +332,12 @@ options.add_options(
         group=options.groups["environment"],
         noxfile=True,
         merge_func=_force_venv_backend_merge_func,
-        help="Virtual environment backend to force-use for all nox sessions in this run, overriding any other venv "
-        "backend declared in the nox file and ignoring the default backend. Any of ``('virtualenv', 'conda', 'mamba', 'venv')`` "
-        "are accepted.",
+        help=(
+            "Virtual environment backend to force-use for all nox sessions in this run,"
+            " overriding any other venv backend declared in the nox file and ignoring"
+            " the default backend. Any of ``('virtualenv', 'conda', 'mamba', 'venv')``"
+            " are accepted."
+        ),
         choices=["none", "virtualenv", "conda", "mamba", "venv"],
     ),
     _option_set.Option(
@@ -339,8 +346,10 @@ options.add_options(
         group=options.groups["environment"],
         default=False,
         action="store_true",
-        help="Runs the selected sessions directly on the current interpreter, without creating a venv. This is an alias "
-        "for '--force-venv-backend none'.",
+        help=(
+            "Runs the selected sessions directly on the current interpreter, without"
+            " creating a venv. This is an alias for '--force-venv-backend none'."
+        ),
     ),
     *_option_set.make_flag_pair(
         "reuse_existing_virtualenvs",
@@ -392,8 +401,8 @@ options.add_options(
         group=options.groups["python"],
         nargs="*",
         help=(
-            "Run sessions with the given interpreters instead of those listed in the Noxfile."
-            " This is a shorthand for ``--python=X.Y --extra-python=X.Y``."
+            "Run sessions with the given interpreters instead of those listed in the"
+            " Noxfile. This is a shorthand for ``--python=X.Y --extra-python=X.Y``."
         ),
         finalizer_func=_force_pythons_finalizer,
     ),
@@ -416,7 +425,10 @@ options.add_options(
         ("--error-on-external-run",),
         ("--no-error-on-external-run",),
         group=options.groups["execution"],
-        help="Error if run() is used to execute a program that isn't installed in a session's virtualenv.",
+        help=(
+            "Error if run() is used to execute a program that isn't installed in a"
+            " session's virtualenv."
+        ),
     ),
     _option_set.Option(
         "install_only",
@@ -449,7 +461,10 @@ options.add_options(
         "--non-interactive",
         group=options.groups["execution"],
         action="store_true",
-        help="Force session.interactive to always be False, even in interactive sessions.",
+        help=(
+            "Force session.interactive to always be False, even in interactive"
+            " sessions."
+        ),
     ),
     _option_set.Option(
         "nocolor",

--- a/nox/command.py
+++ b/nox/command.py
@@ -105,14 +105,16 @@ def run(
         if is_external_tool:
             if external == "error":
                 logger.error(
-                    f"Error: {cmd} is not installed into the virtualenv, it is located at {cmd_path}. "
-                    "Pass external=True into run() to explicitly allow this."
+                    f"Error: {cmd} is not installed into the virtualenv, it is located"
+                    f" at {cmd_path}. Pass external=True into run() to explicitly allow"
+                    " this."
                 )
                 raise CommandFailed("External program disallowed.")
             elif external is False:
                 logger.warning(
-                    f"Warning: {cmd} is not installed into the virtualenv, it is located at {cmd_path}. This might cause issues! "
-                    "Pass external=True into run() to silence this message."
+                    f"Warning: {cmd} is not installed into the virtualenv, it is"
+                    f" located at {cmd_path}. This might cause issues! Pass"
+                    " external=True into run() to silence this message."
                 )
 
     env = _clean_env(env)

--- a/nox/popen.py
+++ b/nox/popen.py
@@ -63,7 +63,8 @@ def popen(
 ) -> tuple[int, str]:
     if silent and stdout is not None:
         raise ValueError(
-            "Can not specify silent and stdout; passing a custom stdout always silences the commands output in Nox's log."
+            "Can not specify silent and stdout; passing a custom stdout always silences"
+            " the commands output in Nox's log."
         )
 
     if silent:

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -437,7 +437,8 @@ class Session:
             prefix_args = ("--prefix", venv.location)
         elif not isinstance(venv, PassthroughEnv):  # pragma: no cover
             raise ValueError(
-                "A session without a conda environment can not install dependencies from conda."
+                "A session without a conda environment can not install dependencies"
+                " from conda."
             )
 
         if not args:
@@ -455,7 +456,8 @@ class Session:
         extraopts: list[str] = []
         if auto_offline and venv.is_offline():
             logger.warning(
-                "Automatically setting the `--offline` flag as conda repo seems unreachable."
+                "Automatically setting the `--offline` flag as conda repo seems"
+                " unreachable."
             )
             extraopts.append("--offline")
 
@@ -664,7 +666,8 @@ class SessionRunner:
             )
         else:
             raise ValueError(
-                f"Expected venv_backend one of ('virtualenv', 'conda', 'mamba', 'venv'), but got '{backend}'."
+                "Expected venv_backend one of ('virtualenv', 'conda', 'mamba',"
+                f" 'venv'), but got '{backend}'."
             )
 
         self.venv.create()

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -63,7 +63,7 @@ def _load_and_exec_nox_module(global_config: Namespace) -> types.ModuleType:
     if not loader:  # pragma: no cover
         raise OSError(f"Could not get module loader for {global_config.noxfile}")
     # See https://docs.python.org/3/library/importlib.html#importing-a-source-file-directly
-    loader.exec_module(module)  # type: ignore[attr-defined]
+    loader.exec_module(module)
     return module
 
 
@@ -200,7 +200,8 @@ def filter_manifest(manifest: Manifest, global_config: Namespace) -> Manifest | 
             ast.parse(global_config.keywords, mode="eval")
         except SyntaxError:
             logger.error(
-                "Error while collecting sessions: keywords argument must be a Python expression."
+                "Error while collecting sessions: keywords argument must be a Python"
+                " expression."
             )
             return 3
 
@@ -254,7 +255,8 @@ def _produce_listing(manifest: Manifest, global_config: Namespace) -> None:
         )
 
     print(
-        f"\nsessions marked with {selected_color}*{reset} are selected, sessions marked with {skipped_color}-{reset} are skipped."
+        f"\nsessions marked with {selected_color}*{reset} are selected, sessions marked"
+        f" with {skipped_color}-{reset} are skipped."
     )
 
 
@@ -299,7 +301,8 @@ def run_manifest(manifest: Manifest, global_config: Namespace) -> list[Result]:
         if WARN_PYTHONS_IGNORED in session.func.should_warn:
             logger.warning(
                 f"Session {session.name} is set to run with venv_backend='none', "
-                f"IGNORING its python={session.func.should_warn[WARN_PYTHONS_IGNORED]} parametrization. "
+                "IGNORING its"
+                f" python={session.func.should_warn[WARN_PYTHONS_IGNORED]} parametrization. "
             )
 
         result = session.execute()

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -486,7 +486,8 @@ class VirtualEnv(ProcessEnv):
         resolved_interpreter_name = os.path.basename(self._resolved_interpreter)
 
         logger.info(
-            f"Creating virtual environment ({self.venv_or_virtualenv}) using {resolved_interpreter_name} in {self.location_name}"
+            f"Creating virtual environment ({self.venv_or_virtualenv}) using"
+            f" {resolved_interpreter_name} in {self.location_name}"
         )
         nox.command.run(cmd, silent=True, log=nox.options.verbose or False)
 

--- a/tests/test_sessions.py
+++ b/tests/test_sessions.py
@@ -612,7 +612,10 @@ class TestSession:
         with mock.patch.object(session, "_run", autospec=True) as run:
             with pytest.warns(
                 FutureWarning,
-                match=r"use of session\.install\(\) is deprecated since it would modify the global Python environment",
+                match=(
+                    r"use of session\.install\(\) is deprecated since it would modify"
+                    r" the global Python environment"
+                ),
             ):
                 session.install("requests", "urllib3")
             run.assert_called_once_with(


### PR DESCRIPTION
Closes #568 

Added bonus is black is now 22.1.0 and the `--preview` flag sorts out long strings automagically!

Only other code change was a `# type: ignore` removal

Edit: I think my VSCode has some yaml formatting coming from somewhere, it seems to have increased the indentation of the whole file making the changeset look bigger than it actually is!