### PR TITLE
tox-to-nox: handle non-identifier env names

### DIFF
--- a/nox/tox_to_nox.jinja2
+++ b/nox/tox_to_nox.jinja2
@@ -2,7 +2,7 @@ import nox
 
 {% for envname, envconfig in config.envconfigs.items()|sort: %}
 @nox.session({%- if envconfig.basepython %}python='{{envconfig.basepython}}'{%- endif %})
-def {{envname}}(session):
+def {{fixname(envname)}}(session):
     {%- set envs = dict(envconfig.setenv) -%}
     {%- do envs.pop('PYTHONHASHSEED', None) -%}
     {%- do envs.pop('TOX_ENV_DIR', None) -%}

--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -33,6 +33,16 @@ def wrapjoin(seq: Iterator[Any]) -> str:
     return ", ".join([f"'{item}'" for item in seq])
 
 
+def fixname(envname: str) -> str:
+    envname = envname.replace("-", "_")
+    if not envname.isidentifier():
+        print(
+            f"Environment {envname!r} is not a valid nox session name.\n"
+            "Manually update the session name in noxfile.py before running nox."
+        )
+    return envname
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Converts toxfiles to noxfiles.")
     parser.add_argument("--output", default="noxfile.py")
@@ -40,7 +50,7 @@ def main() -> None:
     args = parser.parse_args()
 
     config = tox.config.parseconfig([])
-    output = _TEMPLATE.render(config=config, wrapjoin=wrapjoin)
+    output = _TEMPLATE.render(config=config, wrapjoin=wrapjoin, fixname=fixname)
 
     with open(args.output, "w") as outfile:
         outfile.write(output)

--- a/tests/test_tox_to_nox.py
+++ b/tests/test_tox_to_nox.py
@@ -247,3 +247,67 @@ def test_chdir(makeconfig):
     """
         ).lstrip()
     )
+
+
+def test_dash_in_envname(makeconfig):
+    result = makeconfig(
+        textwrap.dedent(
+            """
+            [tox]
+            envlist = test-with-dash
+
+            [testenv:test-with-dash]
+            basepython = python2.7
+            """
+        )
+    )
+
+    assert (
+        result
+        == textwrap.dedent(
+            """
+        import nox
+
+
+        @nox.session(python='python2.7')
+        def test_with_dash(session):
+            session.install('.')
+        """
+        ).lstrip()
+    )
+
+
+def test_non_identifier_in_envname(makeconfig, capfd):
+    result = makeconfig(
+        textwrap.dedent(
+            """
+            [tox]
+            envlist = test-with-&
+
+            [testenv:test-with-&]
+            basepython = python2.7
+            """
+        )
+    )
+
+    assert (
+        result
+        == textwrap.dedent(
+            """
+        import nox
+
+
+        @nox.session(python='python2.7')
+        def test_with_&(session):
+            session.install('.')
+        """
+        ).lstrip()
+    )
+
+    out, _ = capfd.readouterr()
+
+    assert (
+        out
+        == "Environment 'test_with_&' is not a valid nox session name.\n"
+        "Manually update the session name in noxfile.py before running nox.\n"
+    )


### PR DESCRIPTION
Closes #573. Introduces a function which translates dashes to underscores in tox env names and prints a warning if any other non-identifier character is seen in a tox env name.