### PR TITLE
[WIP] Disable running `session.install` outside a venv

### DIFF
--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -532,6 +532,12 @@ class Session:
             session.install('-e', '.')
 
         Additional keyword args are the same as for :meth:`run`.
+        
+        .. warning::
+
+            Running ``session.install`` without a virtual environment
+            is no longer supported. If you still want to do that, please
+            use ``session.run("pip", "install", ...)`` instead.
 
         .. _pip: https://pip.readthedocs.org
         """
@@ -544,13 +550,11 @@ class Session:
                 "A session without a virtualenv can not install dependencies."
             )
         if isinstance(venv, PassthroughEnv):
-            warnings.warn(
+            raise ValueError (
                 f"Session {self.name} does not have a virtual environment, "
-                "so use of session.install() is deprecated since it would modify "
+                "so use of session.install() is no longer allowed since it would modify "
                 "the global Python environment. If you're really sure that is "
-                'what you want to do, use session.run("pip", "install", ...) instead.',
-                category=FutureWarning,
-                stacklevel=2,
+                'what you want to do, use session.run("pip", "install", ...) instead.'
             )
         if not args:
             raise ValueError("At least one argument required to install().")


### PR DESCRIPTION
Toward https://github.com/theacodes/nox/issues/503#issuecomment-968537554.

This PR finishes the work of removing the option of running `session.install` outside a venv, which is possible because we already had a deprecation phase since `2022.1.7` (see #537).

Sorry if I delayed a lot for pushing this, I created the branch a while ago but had several conflicts, and had to restart all the work again :disappointed: [^1].

TODO:

- [x] Disable `session.install` outside a venv
- [ ] Update (or replace?) the test from #537

[^1]: About the branch name, `no-venv-no-install`, I've been thinking about it for a long time. If you've heard or seen the common rule "No shirt, no shoes, no service", you will understand "No venv, no install" :sweat_smile: