### PR TITLE
Added consistent spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,7 +126,7 @@ Special thanks to our contributors:
 - Support users specifying an undeclared parametrization of python via `--extra-python` (#361)
 - Support double-digit minor version in `python` keyword (#367)
 - Add `py.typed` to `manifest.in` (#360)
-- Update nox to latest supported python versions. (#362)
+- Update Nox to latest supported python versions. (#362)
 - Decouple merging of `--python` with `nox.options` from `--sessions` and `--keywords` (#359)
 - Do not merge command-line options in place (#357)
 
@@ -180,7 +180,7 @@ Special thanks to our contributors:
 - Add `venv` as an option for `venv_backend`. (#231)
 - Add gdbgui to list of projects. (#235)
 - Add mypy to Nox's lint. (#230)
-- Add pipx to projects that use nox. (#225)
+- Add pipx to projects that use Nox. (#225)
 - Add `session(venv_backend='conda')` option to use Conda environments. (#217, #221)
 - Document how to call builtins on Windows. (#223)
 - Replace `imp.load_source()` with `importlib`. (#214)
@@ -345,7 +345,7 @@ Other changes:
 
 ## v0.18.1
 
-* Fix nox not returning a non-zero exit code on failure. (#55)
+* Fix Nox not returning a non-zero exit code on failure. (#55)
 * Restore result and report output. (#57)
 
 ## v0.18.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,7 +29,7 @@ side of including lots of information, such as:
 ## Running tests
 
 Nox runs its own tests (it's recursive!). The best thing to do is start with
-a known-good nox installation, e.g. from PyPI:
+a known-good Nox installation, e.g. from PyPI:
 
     pip install --pre --upgrade nox
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ source_suffix = [".rst", ".md"]
 master_doc = "index"
 
 # General information about the project.
-project = "nox"
+project = "Nox"
 copyright = "2016, Alethea Katherine Flowers"
 author = "Alethea Katherine Flowers"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,7 +58,7 @@ source_suffix = [".rst", ".md"]
 master_doc = "index"
 
 # General information about the project.
-project = "Nox"
+project = "nox"
 copyright = "2016, Alethea Katherine Flowers"
 author = "Alethea Katherine Flowers"
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,5 @@
 #
-# nox documentation build configuration file, created by
+# Nox documentation build configuration file, created by
 # sphinx-quickstart on Sun Feb 28 00:05:25 2016.
 #
 # This file is execfile()d with the current directory set to its
@@ -24,7 +24,7 @@ except ImportError:
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-# Note: even though nox is installed when the docs are built, there's a
+# Note: even though Nox is installed when the docs are built, there's a
 # possibility it's installed as a bytecode-compiled binary (.egg). So,
 # include the source anyway.
 sys.path.insert(0, os.path.abspath(".."))

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -254,7 +254,7 @@ latex_elements = {
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
-    (master_doc, "nox.tex", "nox Documentation", "Alethea Katherine Flowers", "manual"),
+    (master_doc, "nox.tex", "Nox Documentation", "Alethea Katherine Flowers", "manual"),
 ]
 
 # The name of an image file (relative to this directory) to place at the top of
@@ -282,7 +282,7 @@ latex_documents = [
 
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
-man_pages = [(master_doc, "nox", "nox Documentation", [author], 1)]
+man_pages = [(master_doc, "nox", "Nox Documentation", [author], 1)]
 
 # If true, show URL addresses after external links.
 # man_show_urls = False
@@ -297,7 +297,7 @@ texinfo_documents = [
     (
         master_doc,
         "nox",
-        "nox Documentation",
+        "Nox Documentation",
         author,
         "nox",
         "One line description of project.",

--- a/docs/cookbook.rst
+++ b/docs/cookbook.rst
@@ -14,7 +14,7 @@ Nox is super easy to get started with, and super powerful right out of the box. 
 
 The kind of sessions that make you think "I didn't know you could do that!"
 
-This cookbook is intended to be a centralized, community-driven repository of awesome Nox sessions to act as a source of inspiration and a reference guide for nox's users. If you're doing something cool with Nox, why not add your session here?
+This cookbook is intended to be a centralized, community-driven repository of awesome Nox sessions to act as a source of inspiration and a reference guide for Nox's users. If you're doing something cool with Nox, why not add your session here?
 
 
 Contributing a Session

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -259,7 +259,7 @@ And if you run ``nox --sessions lint`` Nox will just run the lint session:
     nox > Session lint was successful.
 
 
-In the noxfile, you can specify a default set of sessions to run. If so, a plain
+In the Noxfile, you can specify a default set of sessions to run. If so, a plain
 ``nox`` call will only trigger certain sessions:
 
 .. code-block:: python

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -50,7 +50,7 @@ The order that sessions are executed is the order that they appear in the Noxfil
 Specifying one or more sessions
 -------------------------------
 
-By default Nox will run all sessions defined in the noxfile. However, you can choose to run a particular set of them using ``--session``, ``-s``, or ``-e``:
+By default Nox will run all sessions defined in the Noxfile. However, you can choose to run a particular set of them using ``--session``, ``-s``, or ``-e``:
 
 .. code-block:: console
 
@@ -110,7 +110,7 @@ Then running ``nox --session tests`` will actually run all parametrized versions
 Changing the sessions default backend
 -------------------------------------
 
-By default nox uses ``virtualenv`` as the virtual environment backend for the sessions, but it also supports ``conda``, ``mamba``, and ``venv`` as well as no backend (passthrough to whatever python environment nox is running on). You can change the default behaviour by using ``-db <backend>`` or ``--default-venv-backend <backend>``. Supported names are ``('none', 'virtualenv', 'conda', 'mamba', 'venv')``.
+By default Nox uses ``virtualenv`` as the virtual environment backend for the sessions, but it also supports ``conda``, ``mamba``, and ``venv`` as well as no backend (passthrough to whatever python environment Nox is running on). You can change the default behaviour by using ``-db <backend>`` or ``--default-venv-backend <backend>``. Supported names are ``('none', 'virtualenv', 'conda', 'mamba', 'venv')``.
 
 .. code-block:: console
 
@@ -128,7 +128,7 @@ Note that using this option does not change the backend for sessions where ``ven
 Forcing the sessions backend
 ----------------------------
 
-You might work in a different environment than a project's default continuous integration settings, and might wish to get a quick way to execute the same tasks but on a different venv backend. For this purpose, you can temporarily force the backend used by **all** sessions in the current nox execution by using ``-fb <backend>`` or ``--force-venv-backend <backend>``. No exceptions are made, the backend will be forced for all sessions run whatever the other options values and nox file configuration. Supported names are ``('none', 'virtualenv', 'conda', 'venv')``.
+You might work in a different environment than a project's default continuous integration settings, and might wish to get a quick way to execute the same tasks but on a different venv backend. For this purpose, you can temporarily force the backend used by **all** sessions in the current Nox execution by using ``-fb <backend>`` or ``--force-venv-backend <backend>``. No exceptions are made, the backend will be forced for all sessions run whatever the other options values and Noxfile configuration. Supported names are ``('none', 'virtualenv', 'conda', 'venv')``.
 
 .. code-block:: console
 
@@ -138,7 +138,7 @@ You might work in a different environment than a project's default continuous in
 
 You can also set this option in the Noxfile with ``nox.options.force_venv_backend``. In case both are provided, the commandline argument takes precedence.
 
-Finally note that the ``--no-venv`` flag is a shortcut for ``--force-venv-backend none`` and allows to temporarily run all selected sessions on the current python interpreter (the one running nox).
+Finally note that the ``--no-venv`` flag is a shortcut for ``--force-venv-backend none`` and allows to temporarily run all selected sessions on the current python interpreter (the one running Nox).
 
 .. code-block:: console
 
@@ -206,7 +206,7 @@ using the ``python`` specified for the current ``PATH``::
 Stopping if any session fails
 -----------------------------
 
-By default nox will continue to run all sessions even if one fails. You can use ``--stop-on-first-error`` to make nox abort as soon as the first session fails::
+By default Nox will continue to run all sessions even if one fails. You can use ``--stop-on-first-error`` to make Nox abort as soon as the first session fails::
 
     nox --stop-on-first-error
 
@@ -244,7 +244,7 @@ If the Noxfile sets ``nox.options.error_on_external_run``, you can override the 
 Specifying a different configuration file
 -----------------------------------------
 
-If for some reason your noxfile is not named *noxfile.py*, you can use ``--noxfile`` or ``-f``:
+If for some reason your Noxfile is not named *noxfile.py*, you can use ``--noxfile`` or ``-f``:
 
 .. code-block:: console
 
@@ -257,7 +257,7 @@ If for some reason your noxfile is not named *noxfile.py*, you can use ``--noxfi
 Storing virtualenvs in a different directory
 --------------------------------------------
 
-By default nox stores virtualenvs in ``./.nox``, however, you can change this using ``--envdir``:
+By default Nox stores virtualenvs in ``./.nox``, however, you can change this using ``--envdir``:
 
 .. code-block:: console
 
@@ -331,7 +331,7 @@ Controlling color output
 By default, Nox will output colorful logs if you're using in an interactive
 terminal. However, if you are redirecting ``stderr`` to a file or otherwise
 not using an interactive terminal, or the environment variable ``NO_COLOR`` is
-set, nox will output in plaintext. If this is not set, and ``FORCE_COLOR`` is
+set, Nox will output in plaintext. If this is not set, and ``FORCE_COLOR`` is
 present, color will be forced.
 
 You can manually control Nox's output using the ``--nocolor`` and ``--forcecolor`` flags.
@@ -417,7 +417,7 @@ zsh
     autoload -U bashcompinit
     bashcompinit
 
-    # Afterwards you can enable completion for nox:
+    # Afterwards you can enable completion for Nox:
     eval "$(register-python-argcomplete nox)"
 
 tcsh

--- a/nox/__main__.py
+++ b/nox/__main__.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""The nox `main` module.
+"""The Nox `main` module.
 
 This is the entrypoint for the ``nox`` command (specifically, the ``main``
 function). This module primarily loads configuration, and then passes

--- a/nox/_option_set.py
+++ b/nox/_option_set.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 """High-level options interface. This allows defining options just once that
-can be specified from the command line and the noxfile, easily used in tests,
+can be specified from the command line and the Noxfile, easily used in tests,
 and surfaced in documentation."""
 
 from __future__ import annotations
@@ -113,7 +113,7 @@ def flag_pair_merge_func(
     command_args: Namespace,
     noxfile_args: Namespace,
 ) -> bool:
-    """Merge function for flag pairs. If the flag is set in the noxfile or
+    """Merge function for flag pairs. If the flag is set in the Noxfile or
     the command line params, return ``True`` *unless* the disable flag has been
     specified on the command-line.
 
@@ -162,7 +162,7 @@ def make_flag_pair(
 ) -> tuple[Option, Option]:
     """Returns two options - one to enable a behavior and another to disable it.
 
-    The positive option is considered to be available to the noxfile, as
+    The positive option is considered to be available to the Noxfile, as
     there isn't much point in doing flag pairs without it.
     """
     disable_name = f"no_{name}"
@@ -309,7 +309,7 @@ class OptionSet:
     def merge_namespaces(
         self, command_args: Namespace, noxfile_args: Namespace
     ) -> None:
-        """Merges the command-line options with the noxfile options."""
+        """Merges the command-line options with the Noxfile options."""
         command_args_copy = Namespace(**vars(command_args))
         for name, option in self.options.items():
             if option.merge_func:

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -371,7 +371,7 @@ options.add_options(
         finalizer_func=_R_finalizer,
     ),
     _option_set.Option(
-        "Noxfile",
+        "noxfile",
         "-f",
         "--noxfile",
         group=options.groups["general"],

--- a/nox/_options.py
+++ b/nox/_options.py
@@ -23,7 +23,7 @@ from typing import Any, Sequence
 from nox import _option_set
 from nox.tasks import discover_manifest, filter_manifest, load_nox_module
 
-"""All of nox's configuration options."""
+"""All of Nox's configuration options."""
 
 options = _option_set.OptionSet(
     description="Nox is a Python automation toolkit.", add_help=False
@@ -86,7 +86,7 @@ def _sessions_and_keywords_merge_func(
 def _default_venv_backend_merge_func(
     command_args: argparse.Namespace, noxfile_args: argparse.Namespace
 ) -> str:
-    """Merge default_venv_backend from command args and nox file. Default is "virtualenv".
+    """Merge default_venv_backend from command args and Noxfile. Default is "virtualenv".
 
     Args:
         command_args (_option_set.Namespace): The options specified on the
@@ -104,7 +104,7 @@ def _default_venv_backend_merge_func(
 def _force_venv_backend_merge_func(
     command_args: argparse.Namespace, noxfile_args: argparse.Namespace
 ) -> str:
-    """Merge force_venv_backend from command args and nox file. Default is None.
+    """Merge force_venv_backend from command args and Noxfile. Default is None.
 
     Args:
         command_args (_option_set.Namespace): The options specified on the
@@ -319,7 +319,7 @@ options.add_options(
         noxfile=True,
         merge_func=_default_venv_backend_merge_func,
         help=(
-            "Virtual environment backend to use by default for nox sessions, this is"
+            "Virtual environment backend to use by default for Nox sessions, this is"
             " ``'virtualenv'`` by default but any of ``('virtualenv', 'conda', 'mamba',"
             " 'venv')`` are accepted."
         ),
@@ -333,8 +333,8 @@ options.add_options(
         noxfile=True,
         merge_func=_force_venv_backend_merge_func,
         help=(
-            "Virtual environment backend to force-use for all nox sessions in this run,"
-            " overriding any other venv backend declared in the nox file and ignoring"
+            "Virtual environment backend to force-use for all Nox sessions in this run,"
+            " overriding any other venv backend declared in the Noxfile and ignoring"
             " the default backend. Any of ``('virtualenv', 'conda', 'mamba', 'venv')``"
             " are accepted."
         ),
@@ -371,12 +371,12 @@ options.add_options(
         finalizer_func=_R_finalizer,
     ),
     _option_set.Option(
-        "noxfile",
+        "Noxfile",
         "-f",
         "--noxfile",
         group=options.groups["general"],
         default="noxfile.py",
-        help="Location of the Python file containing nox sessions.",
+        help="Location of the Python file containing Nox sessions.",
     ),
     _option_set.Option(
         "envdir",
@@ -384,7 +384,7 @@ options.add_options(
         noxfile=True,
         merge_func=_envdir_merge_func,
         group=options.groups["environment"],
-        help="Directory where nox will store virtualenvs, this is ``.nox`` by default.",
+        help="Directory where Nox will store virtualenvs, this is ``.nox`` by default.",
     ),
     _option_set.Option(
         "extra_pythons",

--- a/nox/_parametrize.py
+++ b/nox/_parametrize.py
@@ -100,7 +100,7 @@ def parametrize_decorator(
     Add new invocations to the underlying session function using the list of
     ``arg_values_list`` for the given ``arg_names``. Parametrization is
     performed during session discovery and each invocation appears as a
-    separate session to nox.
+    separate session to Nox.
 
     Args:
         arg_names (Sequence[str]): A list of argument names.

--- a/nox/_version.py
+++ b/nox/_version.py
@@ -51,7 +51,7 @@ def _parse_string_constant(node: ast.AST) -> str | None:  # pragma: no cover
 
 
 def _parse_needs_version(source: str, filename: str = "<unknown>") -> str | None:
-    """Parse ``nox.needs_version`` from the user's noxfile."""
+    """Parse ``nox.needs_version`` from the user's Noxfile."""
     value: str | None = None
     module: ast.Module = ast.parse(source, filename=filename)
     for statement in module.body:
@@ -68,7 +68,7 @@ def _parse_needs_version(source: str, filename: str = "<unknown>") -> str | None
 
 
 def _read_needs_version(filename: str) -> str | None:
-    """Read ``nox.needs_version`` from the user's noxfile."""
+    """Read ``nox.needs_version`` from the user's Noxfile."""
     with open(filename) as io:
         source = io.read()
 
@@ -95,12 +95,12 @@ def _check_nox_version_satisfies(needs_version: str) -> None:
 
 
 def check_nox_version(filename: str) -> None:
-    """Check if ``nox.needs_version`` in the user's noxfile is satisfied.
+    """Check if ``nox.needs_version`` in the user's Noxfile is satisfied.
 
     Args:
 
-        filename: The location of the user's noxfile. ``nox.needs_version`` is
-            read from the noxfile by parsing the AST.
+        filename: The location of the user's Noxfile. ``nox.needs_version`` is
+            read from the Noxfile by parsing the AST.
 
     Raises:
         VersionCheckFailed: The Nox version does not satisfy what

--- a/nox/manifest.py
+++ b/nox/manifest.py
@@ -36,7 +36,7 @@ class Manifest:
     """Session manifest.
 
     The session manifest provides the source of truth for the sequence of
-    sessions that should be run by nox.
+    sessions that should be run by Nox.
 
     It is possible for this to be mutated during execution. This allows for
     useful use cases, such as for one session to "notify" another or

--- a/nox/py.typed
+++ b/nox/py.typed
@@ -1,1 +1,1 @@
-# Marker file for PEP 561.  The nox package uses inline types.
+# Marker file for PEP 561.  The Nox package uses inline types.

--- a/nox/sessions.py
+++ b/nox/sessions.py
@@ -59,7 +59,7 @@ def _normalize_path(envdir: str, path: str | bytes) -> str:
             logger.error(
                 f"The virtualenv path {full_path} is too long and will cause issues on "
                 "some environments. Use the --envdir path to modify where "
-                "nox stores virtualenvs."
+                "Nox stores virtualenvs."
             )
 
     return full_path
@@ -272,7 +272,7 @@ class Session:
 
         You can extend the shutdown timeout to allow long-running cleanup tasks to
         complete before being terminated. For example, if you wanted to allow ``pytest``
-        extra time to clean up large projects in the case that nox receives an
+        extra time to clean up large projects in the case that Nox receives an
         interrupt signal from your build system and needs to terminate its child
         processes::
 
@@ -281,7 +281,7 @@ class Session:
                 interrupt_timeout=10.0,
                 terminate_timeout=2.0)
 
-        You can also tell nox to treat non-zero exit codes as success using
+        You can also tell Nox to treat non-zero exit codes as success using
         ``success_codes``. For example, if you wanted to treat the ``pytest``
         "tests discovered, but none selected" error as success::
 
@@ -319,12 +319,12 @@ class Session:
             ``--error-on-external-run``. This has no effect for sessions that
             do not have a virtualenv.
         :type external: bool
-        :param interrupt_timeout: The timeout (in seconds) that nox should wait after it
+        :param interrupt_timeout: The timeout (in seconds) that Nox should wait after it
             and its children receive an interrupt signal before sending a terminate
             signal to its children. Set to ``None`` to never send a terminate signal.
             Default: ``0.3``
         :type interrupt_timeout: float or None
-        :param terminate_timeout: The timeout (in seconds) that nox should wait after it
+        :param terminate_timeout: The timeout (in seconds) that Nox should wait after it
             sends a terminate signal to its children before sending a kill signal to
             them. Set to ``None`` to never send a kill signal.
             Default: ``0.2``
@@ -369,12 +369,12 @@ class Session:
             ``--error-on-external-run``. This has no effect for sessions that
             do not have a virtualenv.
         :type external: bool
-        :param interrupt_timeout: The timeout (in seconds) that nox should wait after it
+        :param interrupt_timeout: The timeout (in seconds) that Nox should wait after it
             and its children receive an interrupt signal before sending a terminate
             signal to its children. Set to ``None`` to never send a terminate signal.
             Default: ``0.3``
         :type interrupt_timeout: float or None
-        :param terminate_timeout: The timeout (in seconds) that nox should wait after it
+        :param terminate_timeout: The timeout (in seconds) that Nox should wait after it
             sends a terminate signal to its children before sending a kill signal to
             them. Set to ``None`` to never send a kill signal.
             Default: ``0.2``
@@ -708,7 +708,7 @@ class SessionRunner:
         logger.warning(f"Running session {self.friendly_name}")
 
         try:
-            # By default, nox should quietly change to the directory where
+            # By default, Nox should quietly change to the directory where
             # the noxfile.py file is located.
             cwd = py.path.local(
                 os.path.realpath(os.path.dirname(self.global_config.noxfile))

--- a/nox/tasks.py
+++ b/nox/tasks.py
@@ -34,18 +34,18 @@ from nox.sessions import Result
 
 def _load_and_exec_nox_module(global_config: Namespace) -> types.ModuleType:
     """
-    Loads, executes, then returns the global_config nox module.
+    Loads, executes, then returns the global_config Nox module.
 
     Args:
         global_config (Namespace): The global config.
 
     Raises:
-        IOError: If the nox module cannot be loaded. This
+        IOError: If the Nox module cannot be loaded. This
             exception is chosen such that it will be caught
             by load_nox_module and logged appropriately.
 
     Returns:
-        types.ModuleType: The initialised nox module.
+        types.ModuleType: The initialised Nox module.
     """
     spec = importlib.util.spec_from_file_location(
         "user_nox_module", global_config.noxfile
@@ -65,7 +65,7 @@ def _load_and_exec_nox_module(global_config: Namespace) -> types.ModuleType:
 
 
 def load_nox_module(global_config: Namespace) -> types.ModuleType | int:
-    """Load the user's noxfile and return the module object for it.
+    """Load the user's Noxfile and return the module object for it.
 
     .. note::
 
@@ -80,7 +80,7 @@ def load_nox_module(global_config: Namespace) -> types.ModuleType | int:
     """
     try:
         # Save the absolute path to the Noxfile.
-        # This will inoculate it if nox changes paths because of an implicit
+        # This will inoculate it if Nox changes paths because of an implicit
         # or explicit chdir (like the one below).
         global_config.noxfile = os.path.realpath(
             # Be sure to expand variables
@@ -130,7 +130,7 @@ def merge_noxfile_options(
 def discover_manifest(
     module: types.ModuleType | int, global_config: Namespace
 ) -> Manifest:
-    """Discover all session functions in the noxfile module.
+    """Discover all session functions in the Noxfile module.
 
     Args:
         module (module): The Noxfile module.
@@ -144,7 +144,7 @@ def discover_manifest(
     # sorted by decorator call time.
     functions = registry.get()
 
-    # Get the docstring from the noxfile
+    # Get the docstring from the Noxfile
     module_docstring = module.__doc__
 
     # Return the final dictionary of session functions.
@@ -163,14 +163,14 @@ def filter_manifest(manifest: Manifest, global_config: Namespace) -> Manifest | 
             the manifest otherwise (to be sent to the next task).
 
     """
-    # Shouldn't happen unless the noxfile is empty
+    # Shouldn't happen unless the Noxfile is empty
     if not manifest:
         logger.error(f"No sessions found in {global_config.noxfile}.")
         return 3
 
     # Filter by the name of any explicit sessions.
     # This can raise KeyError if a specified session does not exist;
-    # log this if it happens. The sessions does not come from the noxfile
+    # log this if it happens. The sessions does not come from the Noxfile
     # if keywords is not empty.
     if global_config.sessions is not None:
         try:
@@ -217,7 +217,7 @@ def filter_manifest(manifest: Manifest, global_config: Namespace) -> Manifest | 
 def _produce_listing(manifest: Manifest, global_config: Namespace) -> None:
     # If the user just asked for a list of sessions, print that
     # and any docstring specified in noxfile.py and be done. This
-    # can also be called if noxfile sessions is an empty list.
+    # can also be called if Noxfile sessions is an empty list.
 
     if manifest.module_docstring:
         print(manifest.module_docstring.strip(), end="\n\n")

--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -38,7 +38,7 @@ def fixname(envname: str) -> str:
     if not envname.isidentifier():
         print(
             f"Environment {envname!r} is not a valid nox session name.\n"
-            "Manually update the session name in noxfile.py before running Nox."
+            "Manually update the session name in noxfile.py before running nox."
         )
     return envname
 

--- a/nox/tox_to_nox.py
+++ b/nox/tox_to_nox.py
@@ -38,7 +38,7 @@ def fixname(envname: str) -> str:
     if not envname.isidentifier():
         print(
             f"Environment {envname!r} is not a valid nox session name.\n"
-            "Manually update the session name in noxfile.py before running nox."
+            "Manually update the session name in noxfile.py before running Nox."
         )
     return envname
 

--- a/nox/virtualenv.py
+++ b/nox/virtualenv.py
@@ -152,7 +152,7 @@ def locate_using_path_and_version(version: str) -> str | None:
 
 
 class PassthroughEnv(ProcessEnv):
-    """Represents the environment used to run nox itself
+    """Represents the environment used to run Nox itself
 
     For now, this class is empty but it might contain tools to grasp some
     hints about the actual env.

--- a/tests/resources/noxfile_multiple_sessions.py
+++ b/tests/resources/noxfile_multiple_sessions.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 import nox
 
 # Deliberately giving these silly names so we know this is not confused
-# with the projects noxfile
+# with the projects Noxfile
 
 
 @nox.session

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -55,7 +55,7 @@ def test_formatter(caplog):
 
     logs = [rec for rec in caplog.records if rec.levelname == "OUTPUT"]
     assert len(logs) == 1
-    # Make sure output level log records are not nox prefixed
+    # Make sure output level log records are not Nox prefixed
     assert "nox" not in logs[0].message
 
 

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -39,7 +39,7 @@ VERSION = metadata.version("nox")
 
 
 # This is needed because CI systems will mess up these tests due to the
-# way nox handles the --session parameter's default value. This avoids that
+# way Nox handles the --session parameter's default value. This avoids that
 # mess.
 os.environ.pop("NOXSESSION", None)
 

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -84,7 +84,7 @@ def test_load_nox_module_not_found(caplog, tmp_path):
 
     assert tasks.load_nox_module(config) == 2
     assert (
-        f"Failed to load Noxfile {bogus_noxfile}, no such file exists." in caplog.text
+        f"Failed to load noxfile {bogus_noxfile}, no such file exists." in caplog.text
     )
 
 
@@ -94,7 +94,7 @@ def test_load_nox_module_os_error(caplog):
     with mock.patch("nox.tasks.check_nox_version", autospec=True) as version_checker:
         version_checker.side_effect = OSError
         assert tasks.load_nox_module(config) == 2
-        assert f"Failed to load Noxfile {noxfile}" in caplog.text
+        assert f"Failed to load noxfile {noxfile}" in caplog.text
 
 
 @pytest.fixture

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -84,7 +84,7 @@ def test_load_nox_module_not_found(caplog, tmp_path):
 
     assert tasks.load_nox_module(config) == 2
     assert (
-        f"Failed to load noxfile {bogus_noxfile}, no such file exists." in caplog.text
+        f"Failed to load Noxfile {bogus_noxfile}, no such file exists." in caplog.text
     )
 
 
@@ -94,7 +94,7 @@ def test_load_nox_module_os_error(caplog):
     with mock.patch("nox.tasks.check_nox_version", autospec=True) as version_checker:
         version_checker.side_effect = OSError
         assert tasks.load_nox_module(config) == 2
-        assert f"Failed to load noxfile {noxfile}" in caplog.text
+        assert f"Failed to load Noxfile {noxfile}" in caplog.text
 
 
 @pytest.fixture

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -65,7 +65,7 @@ def test_load_nox_module():
 
 
 def test_load_nox_module_expandvars():
-    # Assert that variables are expanded when looking up the path to the noxfile
+    # Assert that variables are expanded when looking up the path to the Noxfile
     # This is particular importand in Windows when one needs to use variables like
     # %TEMP% to point to the noxfile.py
     with mock.patch.dict(os.environ, {"RESOURCES_PATH": RESOURCES}):

--- a/tests/test_tox_to_nox.py
+++ b/tests/test_tox_to_nox.py
@@ -308,8 +308,8 @@ def test_non_identifier_in_envname(makeconfig, capfd):
 
     assert (
         out
-        == "Environment 'test_with_&' is not a valid nox session name.\n"
-        "Manually update the session name in noxfile.py before running nox.\n"
+        == "Environment 'test_with_&' is not a valid Nox session name.\n"
+        "Manually update the session name in noxfile.py before running Nox.\n"
     )
 
 

--- a/tests/test_tox_to_nox.py
+++ b/tests/test_tox_to_nox.py
@@ -308,8 +308,8 @@ def test_non_identifier_in_envname(makeconfig, capfd):
 
     assert (
         out
-        == "Environment 'test_with_&' is not a valid Nox session name.\n"
-        "Manually update the session name in noxfile.py before running Nox.\n"
+        == "Environment 'test_with_&' is not a valid nox session name.\n"
+        "Manually update the session name in noxfile.py before running nox.\n"
     )
 
 


### PR DESCRIPTION
Closes #579

This PR aims to fix the inconsistent spelling of `Nox` and `Noxfile` all while leaving the `nox` executables and `noxfile.py` files unchanged.