### PR TITLE
Fix typo in tutorial.rst

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -181,7 +181,7 @@ You can also pass environment variables:
 
     @nox.session
     def tests(session):
-        session.install("black")
+        session.install("pytest")
         session.run(
             "pytest",
             env={


### PR DESCRIPTION
This line should be `session.install("pytest")` from the context.